### PR TITLE
feat(bar): migrate SysTray widget to AGS V3/Gnim

### DIFF
--- a/.config/ags/scss/bar/utilities.scss
+++ b/.config/ags/scss/bar/utilities.scss
@@ -2,17 +2,29 @@
   .system-tray {
     border-radius: 10px;
     padding: 0px;
-    button {
+    button,
+    .systemtray-button {
       border-radius: 0px;
+      padding: 2px 6px;
+      min-width: 24px;
+      min-height: 24px;
     }
-    button:first-child {
+    button:first-child,
+    .systemtray-button:first-child {
       border-radius: 10px 0px 0px 10px;
     }
-    button:last-child {
+    button:last-child,
+    .systemtray-button:last-child {
       border-radius: 0px 10px 10px 0px;
     }
-    button:only-child {
+    button:only-child,
+    .systemtray-button:only-child {
       border-radius: 10px;
+    }
+    .systemtray-icon {
+      font-size: 16px;
+      min-width: 16px;
+      min-height: 16px;
     }
   }
 }


### PR DESCRIPTION
- Replace deprecated binding pattern with <For> component for dynamic list rendering
- Use createBinding() for reactive gicon and tooltipMarkup properties
- Implement proper menu handling using menuModel and actionGroup (GTK3)
- Add TrayItem component for proper per-item state management
- Support primary click (activate/menu), secondary click (menu), middle click (secondary_activate)
- Update SCSS with styles for .systemtray-button and .systemtray-icon

This fixes the "No property actionGroup on GtkMenuButton" error and properly implements the V3 migration pattern using <For> instead of binding((items) => items.map(...)).

