### PR TITLE
fix: prevent hyprpaper memory leak by killing existing instances

### DIFF
--- a/.config/hypr/hyprpaper/load.sh
+++ b/.config/hypr/hyprpaper/load.sh
@@ -18,6 +18,10 @@ all_wallpapers=$HOME/.config/wallpapers/all          # all wallpapers directory
 
 #################################################
 
+# Kill existing hyprpaper instances to prevent memory leak
+killall hyprpaper 2>/dev/null
+sleep 0.5
+
 hyprpaper &
 
 # wait until hyprpaper's IPC socket exists

--- a/.config/hypr/hyprpaper/reload.sh
+++ b/.config/hypr/hyprpaper/reload.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 hyprDir=$HOME/.config/hypr # hypr directory
 
-# hyprctl hyprpaper unload all # unload wallpaper
-killall auto.sh              # kill auto.sh
+# Kill existing hyprpaper and auto.sh to prevent memory leak
+killall hyprpaper 2>/dev/null
+killall auto.sh 2>/dev/null
 
 nohup $hyprDir/hyprpaper/load.sh & # load wallpaper


### PR DESCRIPTION
## Summary

- Fix memory leak caused by multiple hyprpaper instances accumulating over time
- Kill existing hyprpaper process before starting a new one in `load.sh` and `reload.sh`

## Problem

Each wallpaper change or monitor hotplug event spawned a new `hyprpaper` instance without killing the previous one:
- Observed **15 hyprpaper processes** running simultaneously
- VRAM usage reached **3.87 GiB of 4 GiB** (95%) on AMD integrated GPU
- System becomes sluggish due to GPU memory exhaustion

## Changes

**hyprpaper/load.sh:**
- Added `killall hyprpaper` before starting new instance

**hyprpaper/reload.sh:**
- Added `killall hyprpaper` alongside existing `killall auto.sh`

## Test plan

- [ ] Change wallpaper multiple times via workspace switching
- [ ] Run `pgrep -c hyprpaper` - should always return `1`
- [ ] Monitor VRAM usage stays stable over time

Fixes #188