### PR TITLE
fix(ags): use get_connector() for reliable multi-monitor support

### DIFF
--- a/.config/ags/utils/monitor.ts
+++ b/.config/ags/utils/monitor.ts
@@ -18,6 +18,12 @@ export function getConnectorFromHyprland(model: string) {
 }
 
 export function getMonitorName(display: Gdk.Display, monitor: Gdk.Monitor) {
+  // GTK4 provides get_connector() which returns Wayland connector name directly
+  // This is more reliable than matching model strings against hyprctl output
+  const connector = monitor.get_connector();
+  if (connector) return connector;
+
+  // Fallback to old method for compatibility with non-Wayland or older GTK
   const model = monitor.get_model() || monitor.get_description();
   return getConnectorFromHyprland(model as any);
 }


### PR DESCRIPTION
## Summary

Fixes the multi-monitor bar issue where AGS only creates widgets for the first monitor.

## Problem

`getMonitorName()` in `utils/monitor.ts` uses `get_model()` to identify monitors, but this doesn't reliably return values that can be matched against hyprctl output for all monitors. The second monitor often returns `undefined`.

## Solution

Use GTK4's `Gdk.Monitor.get_connector()` which directly returns the Wayland connector name (eDP-1, DP-3, HDMI-A-1, etc.). This is the same naming convention that Hyprland uses, so it's guaranteed to match.

The old method is preserved as a fallback for compatibility.

## Changes

- `utils/monitor.ts`: Use `get_connector()` as primary method, fallback to old hyprctl matching

## Testing

This fix has been running in my fork for several months with:
- Laptop (eDP-1) + external monitor (DP-3) configurations
- Hot-plug connect/disconnect scenarios  
- KVM switch usage (monitors disappear/reappear)

All monitors now correctly receive bars and widgets.

## Related

Fixes #192