### PR TITLE
feat(settings): add file manager selector with auto-detection

### DIFF
--- a/.config/ags/constants/app.constants.ts
+++ b/.config/ags/constants/app.constants.ts
@@ -1,6 +1,22 @@
 import { LauncherApp } from "../interfaces/app.interface";
 import { subprocess, exec, execAsync, createSubprocess } from "ags/process";
-import { setGlobalTheme } from "../variables";
+import { setGlobalTheme, globalSettings } from "../variables";
+
+// File manager command mapping
+const fileManagerCommands: Record<string, string> = {
+  nautilus: "nautilus",
+  thunar: "thunar",
+  dolphin: "dolphin",
+  nemo: "nemo",
+  pcmanfm: "pcmanfm",
+  ranger: "kitty ranger",
+};
+
+// Get the configured file manager command
+const getFileManagerCommand = () => {
+  const fm = globalSettings.peek().fileManager || "nautilus";
+  return fileManagerCommands[fm] || "nautilus";
+};
 
 export const customApps: LauncherApp[] = [
   {
@@ -59,7 +75,7 @@ export const quickApps: LauncherApp[] = [
   },
   {
     app_name: "Files",
-    app_launch: () => execAsync("thunar"),
+    app_launch: () => execAsync(getFileManagerCommand()),
     app_icon: "",
   },
   {

--- a/.config/ags/constants/settings.constants.ts
+++ b/.config/ags/constants/settings.constants.ts
@@ -190,4 +190,5 @@ export const defaultSettings: Settings = {
       timeframe: "",
     },
   },
+  fileManager: "nautilus",
 };

--- a/.config/ags/interfaces/settings.interface.ts
+++ b/.config/ags/interfaces/settings.interface.ts
@@ -88,4 +88,5 @@ export interface Settings {
       timeframe: string;
     };
   };
+  fileManager: string;
 }


### PR DESCRIPTION
## Summary
Adds a File Manager selector in Settings > Custom section with auto-detection of installed file managers.

## Changes
- `settings.interface.ts`: Added `fileManager: string` type
- `settings.constants.ts`: Added default `fileManager: "nautilus"`  
- `SettingsWidget.tsx`: Added `FileManagerSelector` component with togglebuttons
- `app.constants.ts`: Updated Files quick app to use configured file manager

## Features
- Auto-detects installed file managers: nautilus, thunar, dolphin, nemo, pcmanfm, ranger
- Shows only installed options as togglebuttons
- Persists selection to settings.json
- Updates Files quick app dynamically
<img width="836" height="412" alt="imagen" src="https://github.com/user-attachments/assets/d00e0690-f091-409c-9501-ff397ba10d12" />


## Test Plan
- [x] Open Settings > Custom
- [x] Verify only installed file managers appear
- [x] Select different file manager
- [x] Open Files from quick apps
- [x] Verify correct file manager opens