### PR TITLE
fix(booru): prevent action buttons from being cut off in image dialog

### DIFF
--- a/.config/ags/classes/BooruImage.tsx
+++ b/.config/ags/classes/BooruImage.tsx
@@ -394,8 +394,10 @@ export class BooruImage {
 
     const imageRatio = this.getAspectRatio();
     const displayWidth = imageRatio >= 1 ? opts.width * imageRatio : opts.width;
-    const displayHeight =
-      imageRatio >= 1 ? opts.height : opts.height / imageRatio;
+    // Ensure minimum height for action buttons (approx 120px for 2 rows of buttons + tags)
+    const minHeight = 350;
+    const calculatedHeight = imageRatio >= 1 ? opts.height : opts.height / imageRatio;
+    const displayHeight = Math.max(calculatedHeight, minHeight);
 
     // Tags component
     const Tags = () => (
@@ -505,33 +507,28 @@ export class BooruImage {
 
     // Main dialog layout
     return (
-      <overlay
-        widthRequest={displayWidth}
-        heightRequest={displayHeight}
+      <box
+        orientation={Gtk.Orientation.VERTICAL}
         class="booru-image"
         $={async () => {
           setIsDownloaded(this.isDownloaded());
         }}
       >
-        <Picture
-          file={isDownloaded((is) =>
-            is ? this.getImagePath() : this.getPreviewPath()
-          )}
-          height={displayHeight}
-          width={displayWidth}
-          class="image"
-        />
-        <box
-          $type="overlay"
-          orientation={Gtk.Orientation.VERTICAL}
-          widthRequest={displayWidth}
-          heightRequest={displayHeight}
-        >
-          <Tags />
-          <box vexpand />
-          <Actions />
-        </box>
-      </overlay>
+        <overlay widthRequest={displayWidth} heightRequest={displayHeight}>
+          <Picture
+            file={isDownloaded((is) =>
+              is ? this.getImagePath() : this.getPreviewPath()
+            )}
+            height={displayHeight}
+            width={displayWidth}
+            class="image"
+          />
+          <box $type="overlay" orientation={Gtk.Orientation.VERTICAL}>
+            <Tags />
+          </box>
+        </overlay>
+        <Actions />
+      </box>
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes #199

The action buttons in the BooruViewer image popover were being cut off for landscape images because the overlay container had a fixed height based on image dimensions.

## Changes

Restructured the dialog layout in `classes/BooruImage.tsx`:

**Before:**
```
<overlay heightRequest={displayHeight}>
  <Picture />
  <box>
    <Tags />
    <box vexpand />  <!-- spacer pushing actions down -->
    <Actions />      <!-- cut off when height is small -->
  </box>
</overlay>
```

**After:**
```
<box orientation={VERTICAL}>
  <overlay heightRequest={displayHeight}>
    <Picture />
    <box>
      <Tags />       <!-- tags overlay on image -->
    </box>
  </overlay>
  <Actions />        <!-- actions always visible below -->
</box>
```

## Result

- Tags remain as overlay on the image (top)
- Action buttons are now placed **below** the image
- All buttons are always visible regardless of image aspect ratio

## Testing

Tested with:
- Portrait images ✓
- Landscape images ✓
- Multi-monitor setup ✓