### PR TITLE
Update pkglist.txt

### DIFF
--- a/.config/hypr/pacman/pkglist.txt
+++ b/.config/hypr/pacman/pkglist.txt
@@ -116,6 +116,7 @@ python-pywal
 fastfetch
 starship
 gtk4
+libadwaita
 gnome-themes-extra
 gvfs
 hyprlock


### PR DESCRIPTION
>Added libadwaita into the pkglist

Reason for change: Without libadwaita, aylurs-gtk-shell cannot charge into fresh installs. Creating with that an inability to set Wallpapers, Terminal Images and Right panel images.