### PR TITLE
Improvement of .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -12,6 +12,16 @@ source /usr/share/zsh/plugins/zsh-sudo/sudo.plugin.zsh
 source /usr/share/zsh/plugins/zsh-auto-notify/auto-notify.plugin.zsh
 source /usr/share/zsh/plugins/fzf-tab-git/fzf-tab.plugin.zsh
 
+setopt INC_APPEND_HISTORY
+setopt SHARE_HISTORY
+setopt HIST_REDUCE_BLANKS
+setopt HIST_VERIFY
+setopt INC_APPEND_HISTORY
+setopt SHARE_HISTORY
+setopt HIST_FIND_NO_DUPS
+setopt HIST_IGNORE_ALL_DUPS
+setopt HIST_SAVE_NO_DUPS
+
 #Zsh Auto-Suggestions
 ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=#696969,bold"
 HISTSIZE=2000             # Maximum events for internal history


### PR DESCRIPTION
Improvements in quality of life at .zshrc. With this new changes, now the repeated lines will not be saved, which, will only save only one line;

Example: if I type `echo "man"` three times, now it'll be saved once instead of the three times. Of course, it will save any line that you write at your terminal but the repeated ones. List of added functionalities:

`INC_APPEND_HISTORY`: Will write each command typed in any terminal without waiting it to close, is basically a write on live.

`SHARE_HISTORY`: It'll share the used commands on active shells and it will allow you to use the same line on different active shells without closing it. Both of INC_APPEND_HISTORY and SHARE_HISTORY are almost equal, but since their usage must be used at the same time for more compatibility, I thought it would be of use.

`HIST_IGNORE_ALL_DUPS`: If a new command is equal to an older command, then the older will be removed and the new will be added in the most recent way.

`HIST_SAVE_NO_DUPS`: Ensures that zsh will not save older duplicates of newer commands

`HIST_FIND_NO_DUPS`: Prevent the shell of showing the same command line twice when searching at the history file

`HIST_REDUCE_BLANKS`: Automatically removes blanks from the commands history

`HIST_VERIFY`: When using history expansions (!! or !$), it begs for confirmation.

Before using it, I recommend to firt run this command for eliminating the dupes at your history file: `awk '!seen[$0]++' ./history > ./history `. After that, try again with a new open shell with zsh and enjoy the feeling of not having to clic four times the up arrow just for going to another command