### PR TITLE
Update bind.conf

### DIFF
--- a/.config/hypr/configs/bind.conf
+++ b/.config/hypr/configs/bind.conf
@@ -90,7 +90,7 @@ bind = ALT, F10, exec, $keyboardLayout
 ## Plugins
 
 # toggle expo
-bind = SUPER SHIFT, TAB, hyprexpo:expo, toggle
+# bind = SUPER SHIFT, TAB, hyprexpo:expo, toggle
 
 ## Media, Brightness and Volume Controls
 


### PR DESCRIPTION
Hyprexpo has been eliminated from its own repo and with it has been bringing incompatibilities with the most recent Hyprland's Update. This is a momentary take away since its only some commented sets, not a fully eliminated branch of it. Let's wait until they finish the work.