### PR TITLE
refactor: make browser and discord configuration dynamic

### DIFF
--- a/.config/ags/widgets/leftPanel/components/sub-components/General.tsx
+++ b/.config/ags/widgets/leftPanel/components/sub-components/General.tsx
@@ -18,21 +18,29 @@ const GeneralInfo = () => {
   const [isUpdating, setIsUpdating] = createState(false);
   const [updateStatus, setUpdateStatus] = createState("");
 
-  const configDir = GLib.getenv("HOME") + "/.config/ags";
+  // Path to the root of the Git repository (user's home folder)
+  const repoDir = GLib.getenv("HOME") || GLib.get_home_dir();
 
   const checkVersions = async () => {
     setIsCheckingVersion(true);
     try {
-      // Get current local commit
+      // Safely read the list of available remote repositories
+      const remotesOutput = exec(`git -C ${repoDir} remote`) || "";
+      const remotes = remotesOutput.trim().split(/\s+/);
+      const trackingRemote = remotes.includes("upstream") ? "upstream" : "origin";
+
+      // Get the local commit hash
       const localHash = exec(
-        `git -C ${configDir} rev-parse --short HEAD`,
+        `git -C ${repoDir} rev-parse --short HEAD`,
       ).trim();
       setCurrentVersion(localHash);
 
-      // Fetch and get remote commit
-      await execAsync(`git -C ${configDir} fetch origin master`);
+      // Request changes from the correct remote
+      await execAsync(`git -C ${repoDir} fetch ${trackingRemote} master`);
+      
+      // Get the hash of the remote commit
       const remoteHash = await execAsync(
-        `git -C ${configDir} rev-parse --short origin/master`,
+        `git -C ${repoDir} rev-parse --short ${trackingRemote}/master`,
       );
       setRemoteVersion(remoteHash.trim());
       setUpdateStatus("");

--- a/.config/hypr/.gitignore
+++ b/.config/hypr/.gitignore
@@ -1,8 +1,8 @@
-configs/custom/*
-!configs/custom/.gitkeep
-
 config/custom/*
 !config/custom/.gitkeep
+
+config/defaults/*
+!config/defaults/.gitkeep
 
 theme/theme.conf
 wallpaper-daemon/config/*

--- a/.config/hypr/config/defaults/browser.lua
+++ b/.config/hypr/config/defaults/browser.lua
@@ -1,8 +1,8 @@
 hl.on("hyprland.start", function()
-    hl.exec_cmd("zen-browser")
+    hl.exec_cmd("{{ APP_NAME }}")
 end)
 
 hl.window_rule({
-    match = { title = "^(Zen Browser)$" },
+    match = { title = "{{ APP_TITLE }}" },
     workspace = "2 silent",
 })

--- a/.config/hypr/config/defaults/discord_client.lua
+++ b/.config/hypr/config/defaults/discord_client.lua
@@ -1,8 +1,8 @@
 hl.on("hyprland.start", function()
-    hl.exec_cmd("discord")
+    hl.exec_cmd("{{ APP_NAME }}")
 end)
 
 hl.window_rule({
-    match = { class = "^.*cord$" },
+    match = { class = "{{ CLASS_NAME }}" },
     workspace = "6 silent",
 })

--- a/.config/hypr/config/defaults/exec.lua
+++ b/.config/hypr/config/defaults/exec.lua
@@ -1,5 +1,5 @@
 local terminal = "kitty"
 
 hl.on("hyprland.start", function()
-    hl.exec_cmd("[workspace 5 silent] " .. terminal .. " btop")
+    hl.exec_cmd(terminal .. " btop", { workspace = "5 silent" })
 end)

--- a/.config/hypr/maintenance/components/essentials.py
+++ b/.config/hypr/maintenance/components/essentials.py
@@ -11,9 +11,9 @@ from typing import Callable, Optional
 
 if __package__ in (None, ""):
     sys.path.append(str(Path(__file__).resolve().parent.parent))
-    from components.utils import command_exists, run_cmd, run_shell, fzf_select
+    from components.utils import command_exists, fzf_select, run_cmd, run_shell
 else:
-    from .utils import command_exists, run_cmd, run_shell, fzf_select
+    from .utils import command_exists, fzf_select, run_cmd, run_shell
 
 FZF_HEIGHT = "40%"
 
@@ -92,7 +92,7 @@ def install_browser(aur_helper: str = "yay") -> None:
         package = "zen-browser-bin"
         app = "zen-browser"
     elif selection == "firefox":
-        title = "Firefox"
+        title = "Mozilla Firefox"
         package = "firefox"
         app = "firefox"
     elif selection == "chromium":
@@ -106,11 +106,29 @@ def install_browser(aur_helper: str = "yay") -> None:
 
     run_cmd([aur_helper, "-S", "--noconfirm", package])
 
-    config_path = Path.home() / ".config/hypr/configs/defaults/browser.conf"
-    config_path.write_text(
-        f"exec-once = {app} \n windowrule = workspace 2 silent, match:title ^({title})$",
-        encoding="utf-8",
-    )
+    config_path = Path.home() / ".config/hypr/config/custom/browser.lua"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # If the template already exists, read it and change the parameters.
+    # If there is no template, use the default template with markers.
+    if config_path.exists():
+        lua_content = config_path.read_text(encoding="utf-8")
+    else:
+        lua_content = (
+            'hl.on("hyprland.start", function()\n'
+            '    hl.exec_cmd("{{ APP_NAME }}")\n'
+            "end)\n\n"
+            "hl.window_rule({\n"
+            '    match = { title = "^({{ APP_TITLE }})$" },\n'
+            '    workspace = "2 silent",\n'
+            "})\n"
+        )
+
+    # Dynamically replace markers with selected values
+    lua_content = lua_content.replace("{{ APP_NAME }}", app)
+    lua_content = lua_content.replace("{{ APP_TITLE }}", title)
+
+    config_path.write_text(lua_content, encoding="utf-8")
 
 
 def install_discord_client(aur_helper: str = "yay") -> None:
@@ -119,7 +137,7 @@ def install_discord_client(aur_helper: str = "yay") -> None:
     app = ""
 
     print("Choose a Discord client to install (recommended: legcord)")
-    cords = ["legcord", "discord", "betterdiscord"]
+    cords = ["legcord", "discord", "betterdiscord", "vesktop"]
     selection = fzf_select(cords, height=FZF_HEIGHT)
     if not selection:
         print("No Discord client selected.")
@@ -138,15 +156,36 @@ def install_discord_client(aur_helper: str = "yay") -> None:
         class_name = "BetterDiscord"
         package = "betterdiscord"
         app = "betterdiscord"
+    elif selection == "vesktop":
+        class_name = "vesktop"
+        package = "vesktop"
+        app = "vesktop"
 
     run_cmd([aur_helper, "-S", "--noconfirm", package])
 
-    config_path = Path.home() / ".config/hypr/configs/defaults/discord_client.conf"
-    config_path.write_text(
-        f"workspace = 6, gapsout:69, on-created-empty:{class_name} \n "
-        "windowrule = workspace 6 silent, match:class ^.*cord$",
-        encoding="utf-8",
-    )
+    config_path = Path.home() / ".config/hypr/config/custom/discord_client.lua"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # If the template already exists, read it and change the parameters.
+    # If there is no template, use the default template with markers.
+    if config_path.exists():
+        lua_content = config_path.read_text(encoding="utf-8")
+    else:
+        lua_content = (
+            'hl.on("hyprland.start", function()\n'
+            '    hl.exec_cmd("{{ APP_NAME }}")\n'
+            "end)\n\n"
+            "hl.window_rule({\n"
+            '    match = { class = "{{ CLASS_NAME }}" },\n'
+            '    workspace = "6 silent",\n'
+            "})\n"
+        )
+
+    # Dynamically replace markers with selected values
+    lua_content = lua_content.replace("{{ APP_NAME }}", app)
+    lua_content = lua_content.replace("{{ CLASS_NAME }}", class_name)
+
+    config_path.write_text(lua_content, encoding="utf-8")
 
 
 def remove_packages() -> None:

--- a/.config/hypr/maintenance/components/wallpapers.py
+++ b/.config/hypr/maintenance/components/wallpapers.py
@@ -42,7 +42,6 @@ urls_images_sfw = [
     "https://w.wallhaven.cc/full/zp/wallhaven-zpzv7j.jpg",
     "https://w.wallhaven.cc/full/po/wallhaven-polpoe.jpg",
     "https://w.wallhaven.cc/full/w5/wallhaven-w51kxr.jpg",
-    "https://w.wallhaven.cc/full/5y/wallhaven-5y5dp3.jpg",
     "https://w.wallhaven.cc/full/5y/wallhaven-5yz968.jpg",
     "https://w.wallhaven.cc/full/d8/wallhaven-d8395l.jpg",
     "https://w.wallhaven.cc/full/yq/wallhaven-yq56jg.jpg",

--- a/.config/hypr/maintenance/install.py
+++ b/.config/hypr/maintenance/install.py
@@ -186,6 +186,12 @@ def main() -> None:
                 "defaults", "Applying default configurations", default_choice="y"
             ),
             presentation.PlannedStep(
+                "browser", "Setting up browser", default_choice="y"
+            ),
+            presentation.PlannedStep(
+                "discord_client", "Setting up Discord client", default_choice="y"
+            ),
+            presentation.PlannedStep(
                 "wallpapers", "Setting up wallpapers", default_choice="y"
             ),
             presentation.PlannedStep(
@@ -272,6 +278,18 @@ def main() -> None:
         "Applying default configurations",
         modules["defaults"].apply_defaults,
         run=plan["defaults"],
+    )
+    presentation.execute_planned_step(
+        "*",
+        "Setting up browser",
+        lambda helper=aur_helper: modules["essentials"].install_browser(helper),
+        run=plan["browser"],
+    )
+    presentation.execute_planned_step(
+        "*",
+        "Setting up Discord client",
+        lambda helper=aur_helper: modules["essentials"].install_discord_client(helper),
+        run=plan["discord_client"],
     )
     presentation.execute_planned_step(
         "*",


### PR DESCRIPTION
- Replace hardcoded paths and workspace rules with placeholders (`{{APP_NAME}}`, etc.) in default lua configs.
- Refactor installation scripts (`install.py`, `essentials.py`) to prompt for browser and Discord client (adding `vesktop` support) and dynamically generate custom lua configs.
- Update AGS `GeneralInfo` component to perform version checking on the root Git repository using dynamic remote tracking detection.
- Add `config/defaults/*` to Hyprland's `.gitignore`.