### PR TITLE
Update hyprland.lua

### DIFF
--- a/.config/hypr/hyprland.lua
+++ b/.config/hypr/hyprland.lua
@@ -1,4 +1,9 @@
 -- -- Hyprland Lua config entrypoint.
+hl.env("XDG_MENU_PREFIX,arch-", "1")
+hl.env("XDG_CURRENT_DESKTOP,Hyprland", "1")
+hl.env("XDG_SESSION_TYPE,wayland", "1")
+hl.env("XDG_SESSION_DESKTOP,Hyprland", "1")
+
 local function require_all(configs)
     for _, name in ipairs(configs) do
         require("config." .. name)


### PR DESCRIPTION
With this, now the sharing screen function on discord, web browsers and dolphin's file manager "Open With" function is working again, 