### PR TITLE
Added KILL functionality on bind.lua

### DIFF
--- a/.config/hypr/config/bind.lua
+++ b/.config/hypr/config/bind.lua
@@ -27,6 +27,8 @@ local mainMod = "SUPER"
 hl.bind(mainMod .. " + F", hl.dsp.window.fullscreen({ action = "toggle" }))
 -- # close active window
 hl.bind(mainMod .. " + Q", hl.dsp.window.close())
+-- # KILL active window
+hl.bind(mainMod .. " + SHIFT + Q", hl.dsp.window.kill())
 -- # float for active window
 hl.bind(mainMod .. " + Space", hl.dsp.window.float({ action = "toggle" }))
 -- # pin active window


### PR DESCRIPTION
Now, with SUPER + SHIFT + Q you can kill the app instead of letting it on standby-second place.