### PR TITLE
feat: Wallpaper Engine support (live daemon + AGS selector/settings + installer)

### DIFF
--- a/.config/ags/constants/settings.constants.ts
+++ b/.config/ags/constants/settings.constants.ts
@@ -238,6 +238,130 @@ export const defaultSettings: Settings = {
   wallpaperSwitcher: {
     category: "defaults/sfw",
   },
+  wallpaper: {
+    mode: {
+      name: "Wallpaper Mode",
+      value: "workspace",
+      type: "select",
+      min: 0,
+      max: 0,
+      tooltip:
+        "Per Workspace: each workspace can have its own wallpaper.\nGlobal: one wallpaper is used everywhere.",
+    },
+    primarySource: {
+      name: "Primary (Fallback) Wallpaper",
+      value: "workspace1",
+      type: "select",
+      min: 0,
+      max: 0,
+      tooltip:
+        "Used for workspaces with nothing set (and in Global mode if no global wallpaper is chosen).\nWorkspace 1: reuse workspace 1's wallpaper. Custom: use the wallpaper set with the 'primary' target.",
+    },
+    playbackSpeed: {
+      name: "Playback Speed",
+      value: 1,
+      type: "float",
+      min: 0.1,
+      max: 2,
+      tooltip:
+        "Animation speed (1 = normal, 0.5 = half, 2 = double). Applies to video/GIF wallpapers, and to Wallpaper Engine scenes when the patched engine is installed.",
+    },
+  },
+  wallpaperEngine: {
+    scaling: {
+      name: "Scaling Mode",
+      value: "default",
+      type: "select",
+      min: 0,
+      max: 0,
+      tooltip:
+        "How the wallpaper is fit to the screen.\nDefault keeps the author's setting, Fill (Cover) crops to fill, Fit letterboxes, Stretch distorts to fill.",
+    },
+    clamping: {
+      name: "Clamp Mode",
+      value: "clamp",
+      type: "select",
+      min: 0,
+      max: 0,
+      tooltip: "How texture edges are handled (clamp / border / repeat).",
+    },
+    fps: {
+      name: "FPS Limit",
+      value: 30,
+      type: "int",
+      min: 5,
+      max: 240,
+      tooltip: "Frame rate cap. Lower values save battery and GPU.",
+    },
+    renderScale: {
+      name: "Render Scale (Quality)",
+      value: 1,
+      type: "float",
+      min: 0.5,
+      max: 2,
+      tooltip:
+        "Supersampling factor. >1 (e.g. 1.5, 2) antialiases and sharpens 3D/scene wallpapers at higher GPU cost; <1 renders faster. Applied on next wallpaper load.",
+    },
+    volume: {
+      name: "Volume",
+      value: 15,
+      type: "int",
+      min: 0,
+      max: 100,
+      tooltip: "Audio volume (ignored when Mute Audio is on).",
+    },
+    mute: {
+      name: "Mute Audio",
+      value: true,
+      type: "bool",
+      min: 0,
+      max: 1,
+      tooltip: "Mute all sound the wallpaper produces.",
+    },
+    noAutomute: {
+      name: "Disable Auto-mute",
+      value: false,
+      type: "bool",
+      min: 0,
+      max: 1,
+      tooltip:
+        "By default audio mutes when another app plays sound. Enable to keep wallpaper audio playing.",
+    },
+    disableMouse: {
+      name: "Disable Mouse Interaction",
+      value: false,
+      type: "bool",
+      min: 0,
+      max: 1,
+      tooltip: "Stop the wallpaper from reacting to the mouse cursor.",
+    },
+    disableParallax: {
+      name: "Disable Parallax",
+      value: false,
+      type: "bool",
+      min: 0,
+      max: 1,
+      tooltip: "Disable the depth/parallax movement effect.",
+    },
+    noFullscreenPause: {
+      name: "Don't Pause on Fullscreen",
+      value: false,
+      type: "bool",
+      min: 0,
+      max: 1,
+      tooltip:
+        "By default the wallpaper pauses when an app is fullscreen (saves resources). Enable to keep it running.",
+    },
+    audioDevice: {
+      name: "Audio Device (reactive wallpapers)",
+      value: "",
+      type: "string",
+      min: 0,
+      max: 0,
+      tooltip:
+        "PulseAudio/PipeWire source that sound-reactive wallpapers listen to. Empty = system default output. Find names with: pactl list sources short",
+    },
+  },
   apiKeys: {
     openrouter: {
       user: {

--- a/.config/ags/interfaces/settings.interface.ts
+++ b/.config/ags/interfaces/settings.interface.ts
@@ -104,6 +104,24 @@ export interface Settings {
   wallpaperSwitcher: {
     category: string;
   };
+  wallpaper: {
+    mode: AGSSetting;
+    primarySource: AGSSetting;
+    playbackSpeed: AGSSetting;
+  };
+  wallpaperEngine: {
+    scaling: AGSSetting;
+    clamping: AGSSetting;
+    fps: AGSSetting;
+    renderScale: AGSSetting;
+    volume: AGSSetting;
+    mute: AGSSetting;
+    noAutomute: AGSSetting;
+    disableMouse: AGSSetting;
+    disableParallax: AGSSetting;
+    noFullscreenPause: AGSSetting;
+    audioDevice: AGSSetting;
+  };
   apiKeys: {
     openrouter: {
       user: AGSSetting;

--- a/.config/ags/scripts/get-wallpapers.sh
+++ b/.config/ags/scripts/get-wallpapers.sh
@@ -4,109 +4,164 @@
 wallpaper_config="$HOME/.config/hypr/wallpaper-daemon/config"
 wallpaper_folder="$HOME/.config/wallpapers"
 thumbnail_folder="$HOME/.config/ags/cache/thumbnails"
+# Steam Workshop folder for Wallpaper Engine items (read directly, no copying)
+we_folder="$HOME/.local/share/Steam/steamapps/workshop/content/431960"
 
 # Initialize an empty array for the wallpaper paths
 wallpaper_paths=()
+# Parallel map of "<preview path>": "<project type>" for Wallpaper Engine items, so the
+# selector can show the wallpaper TYPE (scene/web/video/application) instead of the
+# preview file's extension. Emitted under the reserved "__types" key.
+wallpaper_types=()
+
+# Image/video extensions we treat as wallpapers
+media_glob=(-iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" -o -iname "*.bmp" -o -iname "*.gif" -o -iname "*.svg" -o -iname "*.mp4" -o -iname "*.webm" -o -iname "*.mkv" -o -iname "*.mov")
+
+# Generate a single 256px thumbnail (skips if it already exists)
+make_thumbnail() {
+    local src="$1" dst="$2"
+    [ -f "$dst" ] && return
+    notify-send "Generating Wallpaper Thumbnail" "Generating wallpaper thumbnail for $(basename "$src")" --expire-time=2000 --urgency=low
+    mkdir -p "$(dirname "$dst")"
+    local ext="${src##*.}"
+    ext="${ext,,}"
+    case "$ext" in
+        mp4|webm|mkv|mov)
+            ffmpeg -y -loglevel error -i "$src" -vf "thumbnail,scale=256:-1" -frames:v 1 "$dst" >/dev/null 2>&1
+            ;;
+        gif)
+            magick "${src}[0]" -resize 256x256 -quality 85 -strip "$dst" >/dev/null 2>&1
+            ;;
+        *)
+            magick "$src" -resize 256x256 -quality 85 -strip "$dst" >/dev/null 2>&1
+            ;;
+    esac
+}
 
 generate_thumbnails() {
     local source_dir="$1"
     local thumb_dir="$2"
-    
-    # Ensure thumbnail directory exists
-    mkdir -p "$thumb_dir"
-    
-    # Generate missing thumbnails in parallel, preserving folder structure
-    find "$source_dir" -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" -o -iname "*.bmp" -o -iname "*.gif" -o -iname "*.svg" -o -iname "*.mp4" -o -iname "*.webm" -o -iname "*.mkv" -o -iname "*.mov" \) | while read -r wallpaper; do
-        # Get relative path from source_dir to preserve folder structure
-        relative_path="${wallpaper#$source_dir/}"
-        relative_no_ext="${relative_path%.*}"
-        thumbnail="$thumb_dir/$relative_no_ext.jpg"
-        ext="${wallpaper##*.}"
-        ext="${ext,,}"
-        
-        # Create subdirectory if needed
-        mkdir -p "$(dirname "$thumbnail")"
-        
-        # Skip if thumbnail already exists
-        if [ ! -f "$thumbnail" ]; then
-            notify-send "Generating Wallpaper Thumbnail" "Generating wallpaper thumbnail for $relative_path" --expire-time=2000 --urgency=low
-            case "$ext" in
-                mp4|webm|mkv|mov)
-                    ffmpeg -y -loglevel error -i "$wallpaper" -vf "thumbnail,scale=256:-1" -frames:v 1 "$thumbnail" >/dev/null 2>&1 &
-                    ;;
-                gif)
-                    magick "${wallpaper}[0]" -resize 256x256 -quality 85 -strip "$thumbnail" >/dev/null 2>&1 &
-                    ;;
-                *)
-                    magick "$wallpaper" -resize 256x256 -quality 85 -strip "$thumbnail" >/dev/null 2>&1 &
-                    ;;
-            esac
-        fi
-    done
-    
-    wait # Ensure all parallel processes finish before proceeding
-    
-    # Remove orphaned thumbnails
-    find "$thumb_dir" -type f | while read -r thumb; do
-        # Get relative path from thumb_dir to match with source structure
-        relative_path="${thumb#$thumb_dir/}"
-        relative_no_ext="${relative_path%.*}"
 
-        original_exists=false
+    mkdir -p "$thumb_dir"
+
+    # Generate missing thumbnails in parallel, preserving folder structure
+    find "$source_dir" -type f \( "${media_glob[@]}" \) | while read -r wallpaper; do
+        local relative_no_ext="${wallpaper#$source_dir/}"
+        relative_no_ext="${relative_no_ext%.*}"
+        make_thumbnail "$wallpaper" "$thumb_dir/$relative_no_ext.jpg" &
+    done
+    wait
+
+    # Remove orphaned thumbnails (skip the wallpaperengine cache, handled below)
+    find "$thumb_dir" -type f | while read -r thumb; do
+        local relative_no_ext="${thumb#$thumb_dir/}"
+        relative_no_ext="${relative_no_ext%.*}"
+        case "$relative_no_ext" in wallpaperengine/*) continue ;; esac
+
+        local original_exists=false
         for ext in jpg jpeg png webp bmp gif svg mp4 webm mkv mov; do
             if [ -f "$source_dir/$relative_no_ext.$ext" ]; then
                 original_exists=true
                 break
             fi
         done
-
-        # Delete thumbnail if original wallpaper is missing
-        if [ "$original_exists" = false ]; then
-            rm "$thumb"
-        fi
+        [ "$original_exists" = false ] && rm "$thumb"
     done
+}
+
+# Build the "wallpaperengine" category directly from the Steam Workshop folder.
+# Each entry's path is the item's preview image; the daemon recovers the id from
+# the parent folder name.
+generate_wallpaperengine() {
+    [ -d "$we_folder" ] || return
+    # Only expose the category when the engine is actually installed.
+    command -v linux-wallpaperengine >/dev/null 2>&1 ||
+        [ -x "$HOME/linux-wallpaperengine/build/output/linux-wallpaperengine" ] || return
+    local we_thumbs="$thumbnail_folder/wallpaperengine"
+    local paths=()
+    mkdir -p "$we_thumbs"
+
+    # Show only items the user is actually SUBSCRIBED to. Steam drops an item from this manifest on
+    # unsubscribe but can leave its content folder on disk until a later cleanup, so listing folders
+    # alone keeps showing unsubscribed wallpapers. Falls back to folder listing if the manifest is
+    # missing/unreadable. Item ids are the bare numeric keys whose value is an object ("{").
+    local acf subscribed=""
+    acf="$(dirname "$(dirname "$we_folder")")/appworkshop_431960.acf"
+    if [ -f "$acf" ]; then
+        subscribed="$(awk '
+            prev ~ /^[ \t]*"[0-9]+"[ \t]*$/ && $0 ~ /^[ \t]*\{[ \t]*$/ { gsub(/[^0-9]/, "", prev); print prev }
+            { prev = $0 }
+        ' "$acf")"
+    fi
+    is_subscribed() { [ -z "$subscribed" ] && return 0; printf '%s\n' "$subscribed" | grep -qx "$1"; }
+
+    # Newest-download-first: order Workshop items by folder mtime (≈ when Steam fetched or
+    # last updated the item) instead of the default glob order (workshop id). Item folder
+    # names are numeric ids with no spaces, so word-splitting the ls output here is safe.
+    for item in $(ls -dt -- "$we_folder"/*/ 2>/dev/null); do
+        local preview
+        preview="$(find "$item" -maxdepth 1 -type f -iname 'preview.*' | head -n 1)"
+        [ -n "$preview" ] || continue
+        local id
+        id="$(basename "$item")"
+        is_subscribed "$id" || continue
+        paths+=("\"$preview\"")
+        # Project type (scene/web/video/application), lower-cased; default "scene".
+        local wtype="scene"
+        if command -v jq >/dev/null 2>&1 && [ -f "$item/project.json" ]; then
+            wtype="$(jq -r '(.type // "scene") | ascii_downcase' "$item/project.json" 2>/dev/null)"
+            [ -n "$wtype" ] && [ "$wtype" != "null" ] || wtype="scene"
+        fi
+        wallpaper_types+=("\"$preview\": \"$wtype\"")
+        make_thumbnail "$preview" "$we_thumbs/$id.jpg" &
+    done
+    wait
+
+    # Expose the type map (consumed by the selector for the per-tile badge).
+    [ ${#wallpaper_types[@]} -gt 0 ] && wallpaper_paths+=("\"__types\": {$(IFS=,; echo "${wallpaper_types[*]}")}")
+
+    # Prune thumbnails for items that are no longer installed
+    for thumb in "$we_thumbs"/*.jpg; do
+        [ -f "$thumb" ] || continue
+        local id="${thumb##*/}"
+        id="${id%.jpg}"
+        { [ -d "$we_folder/$id" ] && is_subscribed "$id"; } || rm -f "$thumb"
+    done
+
+    [ ${#paths[@]} -gt 0 ] && wallpaper_paths+=("\"wallpaperengine\": [$(IFS=,; echo "${paths[*]}")]")
 }
 
 # check if $1 == current
 if [ "$1" == "--current" ]; then
-    # check if $2 is set
     if [ -z "$2" ]; then
         echo "Usage: get-wallpapers.sh --current <monitor>"
         exit 1
-    else
-        monitor=$2
     fi
-    # Read the file line by line
+    monitor=$2
+    # Read the file line by line (only per-workspace keys: w-1, w-2, ...)
     while IFS='=' read -r key path; do
-        # Trim any whitespace from the path and add to the array
+        case "$key" in w-*) ;; *) continue ;; esac
         path=$(echo "$path" | sed "s~^\$HOME~$HOME~" | xargs)
         wallpaper_paths+=("\"$path\"")
     done <"$wallpaper_config/$monitor/defaults.conf"
 
-else
-
-    # Find all directories containing images and preserve full relative path as category
-    while IFS= read -r -d '' dir; do
-        # Get relative path from wallpaper_folder to preserve full category path
-        category="${dir#$wallpaper_folder/}"
-        paths=()
-        while IFS= read -r -d '' file; do
-            paths+=("\"$file\"")
-        done < <(find "$dir" -maxdepth 1 -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" -o -iname "*.bmp" -o -iname "*.gif" -o -iname "*.svg" -o -iname "*.mp4" -o -iname "*.webm" -o -iname "*.mkv" -o -iname "*.mov" \) -print0)
-        
-        # Only add category if it has images
-        if [ ${#paths[@]} -gt 0 ]; then
-            wallpaper_paths+=("\"$category\": [$(IFS=,; echo "${paths[*]}")]")
-        fi
-    done < <(find "$wallpaper_folder" -type d -print0)
-
-    # Generate thumbnails based on all wallpapers found
-    generate_thumbnails "$wallpaper_folder" "$thumbnail_folder"
-    
-    # For categorized wallpapers, output as JSON object
-    (IFS=,; echo "{${wallpaper_paths[*]}}")
+    # For --current mode, output as JSON array
+    echo "[${wallpaper_paths[@]}]" | sed 's/" "/", "/g'
     exit 0
 fi
 
-# For --current mode, output as JSON array
-echo "[${wallpaper_paths[@]}]" | sed 's/" "/", "/g'
+# Find all directories containing images and preserve full relative path as category
+while IFS= read -r -d '' dir; do
+    category="${dir#$wallpaper_folder/}"
+    paths=()
+    while IFS= read -r -d '' file; do
+        paths+=("\"$file\"")
+    done < <(find "$dir" -maxdepth 1 -type f \( "${media_glob[@]}" \) -print0)
+    [ ${#paths[@]} -gt 0 ] && wallpaper_paths+=("\"$category\": [$(IFS=,; echo "${paths[*]}")]")
+done < <(find "$wallpaper_folder" -type d -print0)
+
+generate_thumbnails "$wallpaper_folder" "$thumbnail_folder"
+generate_wallpaperengine
+
+# Output the categorized wallpapers as a JSON object
+(IFS=,; echo "{${wallpaper_paths[*]}}")

--- a/.config/ags/scss/widgets/wallpaper-switcher.scss
+++ b/.config/ags/scss/widgets/wallpaper-switcher.scss
@@ -1,6 +1,98 @@
 .wallpaper-switcher {
   @include module;
 
+  .wallpaper-engine-options {
+    @include module;
+    padding: 10px 15px;
+
+    .setting {
+      label {
+        font-size: 0.85em;
+      }
+    }
+  }
+
+  .we-properties-popover {
+    @include module;
+    padding: 10px;
+
+    .we-property-label {
+      font-size: 0.85em;
+      opacity: 0.85;
+    }
+
+    .we-property-reset {
+      margin-top: 4px;
+    }
+
+    .we-slider-row {
+      .we-slider-value {
+        font-size: 0.8em;
+        opacity: 0.7;
+        min-width: 38px;
+      }
+    }
+
+    // Inline colour picker: a swatch button whose popover holds the RGB picker.
+    // Replaces the system colour dialog (which opens as a stray Hyprland window).
+    .we-color-button {
+      padding: 2px;
+      min-height: 0;
+
+      .we-color-swatch {
+        min-width: 30px;
+        min-height: 20px;
+        border-radius: 6px;
+        border: 1px solid rgba($foreground, 0.25);
+      }
+    }
+  }
+
+  // The colour-picker popover renders inside the layer-shell surface (no window).
+  .we-color-popover {
+    padding: 10px;
+    min-width: 220px;
+
+    .we-color-preview {
+      min-height: 34px;
+      border-radius: 8px;
+      border: 1px solid rgba($foreground, 0.2);
+    }
+
+    .we-color-channel {
+      .we-color-channel-label {
+        font-weight: bold;
+        min-width: 14px;
+        opacity: 0.8;
+      }
+      .we-color-channel-value {
+        font-size: 0.8em;
+        opacity: 0.7;
+        min-width: 30px;
+      }
+      .ch-r highlight {
+        background-color: #e06c75;
+      }
+      .ch-g highlight {
+        background-color: #98c379;
+      }
+      .ch-b highlight {
+        background-color: #61afef;
+      }
+    }
+
+    .we-color-entry-row {
+      .we-color-entry-label {
+        font-size: 0.8em;
+        opacity: 0.7;
+        min-width: 28px;
+      }
+      .we-color-hex {
+        font-family: monospace;
+      }
+    }
+  }
+
   .wallpaper {
     border-radius: 10px;
   }

--- a/.config/ags/utils/scss.ts
+++ b/.config/ags/utils/scss.ts
@@ -35,16 +35,35 @@ export function refreshCss() {
 
   App.reset_css();
   App.apply_css(tmpCss);
+
+  // reset_css() transiently drops the styled sizes (font-size/scale/padding); GTK4 can
+  // then leave a scrolledwindow's content clipped at the wrong height. Force every window
+  // to re-measure so the layout settles to the freshly-applied CSS (this is what a manual
+  // restart was doing — fixing the Super+L settings cutoff after a wallpaper/theme change).
+  for (const win of App.get_windows()) {
+    (win as any).queue_resize?.();
+  }
+}
+
+// A wallpaper change rewrites the wal colors, which can fire the watcher several times in
+// a burst; coalesce them so we don't thrash reset_css/apply_css (and the layout) repeatedly.
+let cssReloadTimer: ReturnType<typeof timeout> | null = null;
+function scheduleCssRefresh() {
+  cssReloadTimer?.cancel?.();
+  cssReloadTimer = timeout(250, () => {
+    cssReloadTimer = null;
+    refreshCss();
+  });
 }
 
 monitorFile(
   // directory that contains the scss files
   `${scss_dir}`,
-  () => refreshCss(),
+  () => scheduleCssRefresh(),
 );
 
 monitorFile(
   // directory that contains pywal colors
   `${GLib.get_home_dir()}/.cache/cwal/colors.scss`,
-  () => refreshCss(),
+  () => scheduleCssRefresh(),
 );

--- a/.config/ags/widgets/WallpaperEngineProperties.tsx
+++ b/.config/ags/widgets/WallpaperEngineProperties.tsx
@@ -1,0 +1,405 @@
+import { createState, For, With } from "ags";
+import { execAsync } from "ags/process";
+import { Gtk } from "ags/gtk4";
+import { timeout } from "ags/time";
+import GLib from "gi://GLib";
+import { readJson } from "../utils/json";
+import { notify } from "../utils/notification";
+
+const DAEMON = `${GLib.get_home_dir()}/.config/hypr/wallpaper-daemon`;
+
+interface WeProp {
+  key: string;
+  type: string;
+  text: string;
+  value: any;
+  options?: any[] | null;
+  min?: number | null;
+  max?: number | null;
+  step?: number | null;
+}
+
+type RGB = [number, number, number];
+
+const clamp255 = (n: number) => Math.max(0, Math.min(255, Math.round(n * 255)));
+
+// "0.5 0.25 1" (WE color, components 0..1) -> [0.5, 0.25, 1].
+function parseColor(value: any): RGB {
+  const p = String(value).trim().split(/\s+/).map(Number);
+  return [p[0] || 0, p[1] || 0, p[2] || 0];
+}
+
+function rgbCss([r, g, b]: RGB): string {
+  return `rgb(${clamp255(r)},${clamp255(g)},${clamp255(b)})`;
+}
+
+function rgbToHex([r, g, b]: RGB): string {
+  const h = (n: number) => clamp255(n).toString(16).padStart(2, "0");
+  return `#${h(r)}${h(g)}${h(b)}`;
+}
+
+function hexToRgb(hex: string): RGB | null {
+  const m = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
+  if (!m) return null;
+  const n = parseInt(m[1], 16);
+  return [((n >> 16) & 255) / 255, ((n >> 8) & 255) / 255, (n & 255) / 255];
+}
+
+// linux-wallpaperengine reads a color WITHOUT a decimal point as 0..255 and WITH
+// one as 0..1; we always emit floats 0..1 with a forced decimal point.
+function rgbToWe([r, g, b]: RGB): string {
+  return `${r.toFixed(5)} ${g.toFixed(5)} ${b.toFixed(5)}`;
+}
+
+function normalizeWeColor(value: any): string {
+  return rgbToWe(parseColor(value));
+}
+
+function isTruthy(v: any): boolean {
+  return v === true || v === 1 || v === "1" || v === "true";
+}
+
+// Show slider values with just enough precision to be useful but not noisy.
+function fmtNumber(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return n.toFixed(Math.abs(n) < 1 ? 3 : 2);
+}
+
+/**
+ * Inline RGB colour picker. Replaces Gtk.ColorButton, whose system colour
+ * chooser opens as a separate top-level window (a floating/tiled app window on
+ * Hyprland). A nested popover renders inside the layer-shell surface instead, so
+ * the picker stays attached to the menu — no stray window.
+ */
+function ColorControl({
+  value,
+  onChange,
+}: {
+  value: any;
+  onChange: (we: string, debounce: boolean) => void;
+}) {
+  const init = parseColor(value);
+  const [color, setColor] = createState<RGB>(init);
+
+  const setChannel = (index: number, v: number) => {
+    const next = [...color.peek()] as RGB;
+    next[index] = v;
+    setColor(next);
+    onChange(rgbToWe(next), true);
+  };
+
+  const Channel = ({ label, index }: { label: string; index: number }) => (
+    <box class="we-color-channel" spacing={6} valign={Gtk.Align.CENTER}>
+      <label class="we-color-channel-label" label={label} />
+      <slider
+        class={`we-color-slider ch-${label.toLowerCase()}`}
+        widthRequest={150}
+        hexpand
+        min={0}
+        max={1}
+        step={1 / 255}
+        value={init[index]}
+        onValueChanged={(self) => setChannel(index, self.get_value())}
+      />
+      <label
+        class="we-color-channel-value"
+        label={color((c) => String(clamp255(c[index])))}
+      />
+    </box>
+  );
+
+  return (
+    <menubutton
+      class="we-color-button"
+      valign={Gtk.Align.CENTER}
+      halign={Gtk.Align.START}
+    >
+      <box
+        class="we-color-swatch"
+        css={color((c) => `background-color: ${rgbCss(c)};`)}
+      />
+      <popover>
+        <box
+          class="we-color-popover"
+          orientation={Gtk.Orientation.VERTICAL}
+          spacing={8}
+        >
+          <box
+            class="we-color-preview"
+            css={color((c) => `background-color: ${rgbCss(c)};`)}
+          />
+          <Channel label="R" index={0} />
+          <Channel label="G" index={1} />
+          <Channel label="B" index={2} />
+          <box class="we-color-entry-row" spacing={6} valign={Gtk.Align.CENTER}>
+            <label class="we-color-entry-label" label="Hex" />
+            <entry
+              class="we-color-hex"
+              hexpand
+              text={color((c) => rgbToHex(c))}
+              onActivate={(self) => {
+                const rgb = hexToRgb(self.text);
+                if (rgb) {
+                  setColor(rgb);
+                  onChange(rgbToWe(rgb), false);
+                }
+              }}
+            />
+          </box>
+        </box>
+      </popover>
+    </menubutton>
+  );
+}
+
+/** Slider with a live numeric readout next to it. */
+function SliderControl({
+  prop,
+  onChange,
+}: {
+  prop: WeProp;
+  onChange: (value: string, debounce: boolean) => void;
+}) {
+  const [val, setVal] = createState<number>(Number(prop.value) || 0);
+  return (
+    <box class="we-slider-row" spacing={8} valign={Gtk.Align.CENTER} halign={Gtk.Align.START}>
+      <slider
+        widthRequest={180}
+        hexpand={false}
+        min={prop.min ?? 0}
+        max={prop.max ?? 1}
+        step={prop.step ?? 0.01}
+        value={Number(prop.value) || 0}
+        onValueChanged={(self) => {
+          setVal(self.get_value());
+          onChange(String(self.get_value()), true);
+        }}
+      />
+      <label class="we-slider-value" label={val((v) => fmtNumber(v))} />
+    </box>
+  );
+}
+
+/**
+ * Dynamic per-wallpaper Wallpaper Engine property editor. Reads whatever
+ * properties the currently-applied wallpaper declares (bool / slider / color /
+ * combo / textinput) and writes overrides that get passed via --set-property.
+ */
+export function WallpaperEngineProperties({
+  monitorName,
+}: {
+  monitorName: string;
+}) {
+  const [weId, setWeId] = createState<string>("");
+  const [props, setProps] = createState<WeProp[]>([]);
+
+  // Debounce timers per property so dragging a slider doesn't relaunch the
+  // engine on every tick.
+  const timers = new Map<string, ReturnType<typeof timeout>>();
+
+  const setProp = (key: string, value: string, debounce = false) => {
+    const id = weId.peek();
+    if (!id) return;
+    const apply = () => {
+      // Persist the override, then push it over the control socket. The engine applies everything
+      // live: plain values update uniforms in place, and visibility-gating properties (coloring
+      // combos, xray) trigger a flash-free in-process rebuild. Reload only if the socket is gone.
+      execAsync(["bash", `${DAEMON}/wallpaperengine-properties.sh`, "--set", id, key, value])
+        .then(() =>
+          execAsync([
+            "bash",
+            `${DAEMON}/wallpaperengine-ctl.sh`,
+            "property",
+            key,
+            value,
+          ]).catch(() =>
+            execAsync(["bash", `${DAEMON}/apply-current.sh`, monitorName]),
+          ),
+        )
+        .catch((err) => notify({ summary: "Error", body: String(err) }));
+    };
+    if (debounce) {
+      timers.get(key)?.cancel?.();
+      timers.set(key, timeout(450, apply));
+    } else {
+      apply();
+    }
+  };
+
+  const load = async () => {
+    try {
+      const id = (
+        await execAsync(
+          `bash ${DAEMON}/wallpaperengine-properties.sh --current ${monitorName}`,
+        )
+      ).trim();
+      setWeId(id);
+      if (!id) {
+        setProps([]);
+        return;
+      }
+      const out = await execAsync(
+        `bash ${DAEMON}/wallpaperengine-properties.sh --list ${id}`,
+      );
+      setProps((readJson(out) as WeProp[]) || []);
+    } catch (e) {
+      setProps([]);
+    }
+  };
+
+  const resetAll = () => {
+    const id = weId.peek();
+    if (!id) return;
+    // Clearing overrides needs a reload to restore the wallpaper's defaults.
+    execAsync(`bash ${DAEMON}/wallpaperengine-properties.sh --reset ${id}`)
+      .then(() => execAsync(`bash ${DAEMON}/apply-current.sh ${monitorName}`))
+      .then(load)
+      .catch((err) => notify({ summary: "Error", body: String(err) }));
+  };
+
+  const Control = (p: WeProp) => {
+    switch (p.type) {
+      case "bool":
+        return (
+          <switch
+            valign={Gtk.Align.CENTER}
+            halign={Gtk.Align.START}
+            hexpand={false}
+            active={isTruthy(p.value)}
+            onNotifyActive={(self) =>
+              setProp(p.key, self.active ? "true" : "false")
+            }
+          />
+        );
+      case "slider":
+        return (
+          <SliderControl
+            prop={p}
+            onChange={(value, debounce) => setProp(p.key, value, debounce)}
+          />
+        );
+      case "combo": {
+        const opts = p.options || [];
+        // Combos that ship no default value report value:null; Wallpaper Engine treats that as the
+        // first option, so reflect that here instead of showing nothing selected.
+        const firstValue = opts.length ? String(opts[0]?.value ?? opts[0]) : "";
+        const current =
+          p.value === null || p.value === undefined || p.value === ""
+            ? firstValue
+            : String(p.value);
+        return (
+          <box
+            class="we-combo"
+            spacing={4}
+            halign={Gtk.Align.START}
+            hexpand={false}
+            $={(self: any) => {
+              // A combo is single-choice. Link the option togglebuttons into one GTK radio group so
+              // selecting one releases the others — previously they were independent toggles, so several
+              // could read as "active" at once and a stray value could be written for the wrong key.
+              let leader: any = null;
+              for (let c = self.get_first_child(); c != null; c = c.get_next_sibling()) {
+                if (leader === null) leader = c;
+                else c.set_group?.(leader);
+              }
+            }}
+          >
+            {opts.map((o: any) => {
+              const label = String(o?.label ?? o?.text ?? o?.value ?? o);
+              const value = String(o?.value ?? o);
+              return (
+                <togglebutton
+                  label={label}
+                  active={current === value}
+                  onToggled={({ active }) => active && setProp(p.key, value)}
+                />
+              );
+            })}
+          </box>
+        );
+      }
+      case "color":
+        return (
+          <ColorControl
+            value={p.value}
+            onChange={(we, debounce) => setProp(p.key, we, debounce)}
+          />
+        );
+      default:
+        // textinput and anything unknown -> plain text entry
+        return (
+          <entry
+            widthRequest={160}
+            halign={Gtk.Align.START}
+            hexpand={false}
+            text={String(p.value ?? "")}
+            onActivate={(self) => setProp(p.key, self.text)}
+          />
+        );
+    }
+  };
+
+  return (
+    <menubutton class="we-properties" halign={Gtk.Align.CENTER}>
+      <label label=" Properties" />
+      <popover
+        $={(self) => {
+          // (Re)load whenever the popover is opened.
+          self.connect("show", load);
+        }}
+      >
+        <box
+          orientation={Gtk.Orientation.VERTICAL}
+          spacing={8}
+          class="popover we-properties-popover"
+          widthRequest={340}
+        >
+          <With value={weId}>
+            {(id) =>
+              !id ? (
+                <label
+                  label="Apply a Wallpaper Engine wallpaper to customize it."
+                  wrap
+                />
+              ) : (
+                <box orientation={Gtk.Orientation.VERTICAL} spacing={8}>
+                  <Gtk.ScrolledWindow
+                    hscrollbarPolicy={Gtk.PolicyType.NEVER}
+                    vscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
+                    heightRequest={360}
+                    propagateNaturalHeight
+                  >
+                    <box orientation={Gtk.Orientation.VERTICAL} spacing={10}>
+                      <For each={props}>
+                        {(p) => (
+                          <box
+                            class="we-property"
+                            orientation={Gtk.Orientation.VERTICAL}
+                            spacing={3}
+                          >
+                            <label
+                              class="we-property-label"
+                              label={p.text || p.key}
+                              xalign={0}
+                              wrap
+                            />
+                            {Control(p)}
+                          </box>
+                        )}
+                      </For>
+                    </box>
+                  </Gtk.ScrolledWindow>
+                  <button
+                    class="we-property-reset"
+                    label="Reset to defaults"
+                    onClicked={resetAll}
+                  />
+                </box>
+              )
+            }
+          </With>
+        </box>
+      </popover>
+    </menubutton>
+  );
+}

--- a/.config/ags/widgets/WallpaperSwitcher.tsx
+++ b/.config/ags/widgets/WallpaperSwitcher.tsx
@@ -19,11 +19,40 @@ import { Gdk } from "ags/gtk4";
 import { formatKiloBytes } from "../utils/bytes";
 import { readJson } from "../utils/json";
 import GLib from "gi://GLib";
+import {
+  Setting,
+  weScalingChoices,
+  weClampChoices,
+  wallpaperModeChoices,
+  applyCurrentWallpapers,
+  controlWE,
+} from "./leftPanel/components/SettingsWidget";
+
+import { WallpaperEngineProperties } from "./WallpaperEngineProperties";
+
+export const WALLPAPER_ENGINE_CATEGORY = "wallpaperengine";
 
 export function toThumbnailPath(file: string) {
+  // Wallpaper Engine items live under the Steam Workshop folder; their thumbnail
+  // is cached by id under thumbnails/wallpaperengine/<id>.jpg.
+  const we = file.match(/\/workshop\/content\/431960\/([^/]+)\//);
+  if (we)
+    return `${GLib.get_home_dir()}/.config/ags/cache/thumbnails/wallpaperengine/${we[1]}.jpg`;
+
   return file
     .replace("/.config/wallpapers/", "/.config/ags/cache/thumbnails/")
     .replace(/\.[^/.]+$/, ".jpg");
+}
+
+// A Wallpaper Engine item is identified by its Workshop content path.
+export function isWallpaperEngine(file: string) {
+  return file.includes("/workshop/content/431960/");
+}
+
+// Human-friendly label for category keys (folder names) shown in the selector.
+export function prettyCategory(category: string) {
+  if (category === WALLPAPER_ENGINE_CATEGORY) return "Wallpaper Engine";
+  return category;
 }
 
 export default ({
@@ -41,10 +70,26 @@ export default ({
     "loading" | "error" | "success" | "idle"
   >("idle");
 
-  const targetTypes = ["workspace", "sddm", "lockscreen"];
+  const targetTypes = ["workspace", "primary", "sddm", "lockscreen"];
   const [targetType, setTargetType] = createState<string>("workspace");
 
-  const [wallpapers, setWallpapers] = createState<Record<string, string[]>>({});
+  // Values are string[] for categories, plus a reserved "__types" object map
+  // (preview path -> WE project type) — hence `any`.
+  const [wallpapers, setWallpapers] = createState<Record<string, any>>({});
+
+  // Category keys for the selector, excluding reserved "__"-prefixed metadata keys.
+  const wallpaperCategories = (w: Record<string, any>) =>
+    Object.keys(w).filter((k) => !k.startsWith("__"));
+
+  // Badge text for a tile: the WE project type (scene/web/video/application) for
+  // Wallpaper Engine items, otherwise an image/video label from the file extension.
+  function wallpaperBadge(path: string): string {
+    if (isWallpaperEngine(path)) {
+      return (wallpapers() as any).__types?.[path] || "scene";
+    }
+    const ext = (path.split(".").pop() || "").toLowerCase();
+    return ["mp4", "webm", "mkv", "mov", "gif"].includes(ext) ? "video" : "image";
+  }
 
   const selectedWallpapers = createComputed(() => {
     return (
@@ -54,18 +99,34 @@ export default ({
     );
   });
 
+  // Raw JSON of the last successful scan; used to skip a full re-render (rebuilding
+  // every tile/Picture) when an open or folder event produced no actual change.
+  let lastWallpapersJson = "";
   async function FetchWallpapers() {
     try {
       // Added await so that the function actually waits for the bash script to complete.
       const output = await execAsync(
         `bash ${GLib.get_home_dir()}/.config/ags/scripts/get-wallpapers.sh`,
       );
+      if (output === lastWallpapersJson) return; // nothing changed -> no re-render
+      lastWallpapersJson = output;
       const wallpapers = readJson(output);
       setWallpapers(wallpapers);
     } catch (err) {
       notify({ summary: "Error", body: String(err) });
       print("Error fetching wallpapers: " + String(err));
     }
+  }
+
+  // Coalesce bursts of filesystem events (a single Workshop download touches many
+  // files) into one rescan so we don't run get-wallpapers.sh dozens of times.
+  let rescanTimer: ReturnType<typeof timeout> | null = null;
+  function scheduleRescan() {
+    rescanTimer?.cancel();
+    rescanTimer = timeout(750, () => {
+      rescanTimer = null;
+      FetchWallpapers();
+    });
   }
 
   const [currentWallpapers, setCurrentWallpapers] = createState<string[]>([]);
@@ -159,12 +220,18 @@ export default ({
                 const handleLeftClick = (self: Gtk.Button) => {
                   setProgressStatus("loading");
                   const target = targetType.peek();
+                  const monitorName = (self.get_root() as any).monitorName;
+                  // In Global mode the "workspace" target writes the single
+                  // global wallpaper; otherwise the selected workspace.
+                  const slot =
+                    globalSettings.peek().wallpaper.mode.value === "global"
+                      ? "global"
+                      : selectedWorkspaceId.peek();
                   const command = {
                     sddm: `pkexec bash -c 'sed -i "s|^background=.*|background=${wallpaper}|" /usr/share/sddm/themes/where_is_my_sddm_theme/theme.conf'`,
                     lockscreen: `bash -c "mkdir -p $HOME/.config/wallpapers/lockscreen && cp ${wallpaper} $HOME/.config/wallpapers/lockscreen/wallpaper"`,
-                    workspace: `bash -c "$HOME/.config/hypr/wallpaper-daemon/set-wallpaper.sh ${selectedWorkspaceId.peek()} ${
-                      (self.get_root() as any).monitorName
-                    } ${wallpaper}"`,
+                    workspace: `bash -c "$HOME/.config/hypr/wallpaper-daemon/set-wallpaper.sh ${slot} ${monitorName} ${wallpaper}"`,
+                    primary: `bash -c "$HOME/.config/hypr/wallpaper-daemon/set-wallpaper.sh primary ${monitorName} ${wallpaper}"`,
                   }[target];
 
                   execAsync(command!)
@@ -184,6 +251,15 @@ export default ({
                 };
 
                 const handleRightClick = () => {
+                  // Never delete Wallpaper Engine items from disk (they belong to
+                  // Steam); manage those through the Steam Workshop instead.
+                  if (isWallpaperEngine(wallpaper)) {
+                    notify({
+                      summary: "Wallpaper Engine",
+                      body: "Unsubscribe from this item in Steam to remove it.",
+                    });
+                    return;
+                  }
                   setProgressStatus("loading");
                   execAsync(
                     `bash -c "rm -f '${toThumbnailPath(
@@ -255,7 +331,7 @@ export default ({
                     <Picture
                       class="wallpaper"
                       file={toThumbnailPath(wallpaper)}
-                      info={[wallpaper.split(".").pop() || "unknown"]}
+                      info={[wallpaperBadge(wallpaper)]}
                     ></Picture>
                   </button>
                 ) as Gtk.Widget;
@@ -297,8 +373,12 @@ export default ({
             selectedWallpapers.peek()[
               Math.floor(Math.random() * selectedWallpapers.peek().length)
             ];
+          const slot =
+            globalSettings.peek().wallpaper.mode.value === "global"
+              ? "global"
+              : selectedWorkspaceId.peek();
           execAsync(
-            `bash -c "$HOME/.config/hypr/wallpaper-daemon/set-wallpaper.sh ${selectedWorkspaceId.peek()} ${
+            `bash -c "$HOME/.config/hypr/wallpaper-daemon/set-wallpaper.sh ${slot} ${
               (self.get_root() as any).monitorName
             } ${randomWallpaper}"`,
           )
@@ -465,8 +545,8 @@ export default ({
     const categorySelector = (
       <menubutton class="category-selector" halign={Gtk.Align.CENTER}>
         <label
-          label={globalSettings(
-            ({ wallpaperSwitcher }) => wallpaperSwitcher.category,
+          label={globalSettings(({ wallpaperSwitcher }) =>
+            prettyCategory(wallpaperSwitcher.category),
           )}
         />
         <popover>
@@ -477,10 +557,10 @@ export default ({
                 spacing={5}
                 class={"popover"}
               >
-                {Object.keys(wallpapers).map((category) => (
+                {wallpaperCategories(wallpapers).map((category) => (
                   <button
                     class={"category"}
-                    label={category}
+                    label={prettyCategory(category)}
                     onClicked={() =>
                       setGlobalSetting("wallpaperSwitcher.category", category)
                     }
@@ -493,6 +573,27 @@ export default ({
       </menubutton>
     );
 
+    const modeSelector = (
+      <Setting
+        compact
+        keyChanged="wallpaper.mode"
+        setting={globalSettings.peek().wallpaper.mode}
+        choices={wallpaperModeChoices}
+        callBack={applyCurrentWallpapers}
+      />
+    );
+
+    // Playback speed applies to video/GIF wallpapers (via mpvpaper). Wallpaper
+    // Engine scenes have no speed control in the engine yet.
+    const speedSelector = (
+      <Setting
+        compact
+        keyChanged="wallpaper.playbackSpeed"
+        setting={globalSettings.peek().wallpaper.playbackSpeed}
+        callBack={(v) => controlWE(`speed ${v}`)}
+      />
+    );
+
     const actions = (
       <box
         class="actions"
@@ -502,6 +603,8 @@ export default ({
       >
         {targetButtons}
         {selectedWorkspaceLabel}
+        {modeSelector}
+        {speedSelector}
         {displayColorScheme}
         {categorySelector}
         {randomButton}
@@ -514,14 +617,83 @@ export default ({
       </box>
     );
 
+    // Live Wallpaper Engine controls, revealed only while the Wallpaper Engine
+    // category is selected. Changing a value re-renders the active live
+    // wallpaper(s) immediately. Full set of options lives in Settings.
+    const wallpaperEngineOptions = (
+      <revealer
+        transitionType={Gtk.RevealerTransitionType.SLIDE_DOWN}
+        revealChild={globalSettings(
+          ({ wallpaperSwitcher }) =>
+            wallpaperSwitcher.category === WALLPAPER_ENGINE_CATEGORY,
+        )}
+      >
+        <box
+          class="wallpaper-engine-options"
+          halign={Gtk.Align.CENTER}
+          spacing={20}
+        >
+          <Setting
+            compact
+            keyChanged="wallpaperEngine.scaling"
+            setting={globalSettings.peek().wallpaperEngine.scaling}
+            choices={weScalingChoices}
+            callBack={(v) => controlWE(`scaling ${v}`)}
+          />
+          <Setting
+            compact
+            keyChanged="wallpaperEngine.clamping"
+            setting={globalSettings.peek().wallpaperEngine.clamping}
+            choices={weClampChoices}
+            callBack={(v) => controlWE(`clamp ${v}`)}
+          />
+          <Setting
+            compact
+            keyChanged="wallpaperEngine.fps"
+            setting={globalSettings.peek().wallpaperEngine.fps}
+            callBack={(v) => controlWE(`set fps ${v}`)}
+          />
+          <Setting
+            compact
+            keyChanged="wallpaperEngine.volume"
+            setting={globalSettings.peek().wallpaperEngine.volume}
+            callBack={(v) => controlWE(`volume ${v}`)}
+          />
+          <Setting
+            compact
+            keyChanged="wallpaperEngine.mute"
+            setting={globalSettings.peek().wallpaperEngine.mute}
+            callBack={(v) => controlWE(`mute ${v ? 1 : 0}`)}
+          />
+          <WallpaperEngineProperties monitorName={monitorName} />
+        </box>
+      </revealer>
+    );
+
     return (
       <box
         class="wallpaper-switcher"
         orientation={Gtk.Orientation.VERTICAL}
         spacing={20}
       >
-        {getCurrentWorkspaces}
+        <box
+          visible={globalSettings(
+            ({ wallpaper }) => wallpaper.mode.value !== "global",
+          )}
+        >
+          {getCurrentWorkspaces}
+        </box>
+        <box
+          class="global-indicator"
+          halign={Gtk.Align.CENTER}
+          visible={globalSettings(
+            ({ wallpaper }) => wallpaper.mode.value === "global",
+          )}
+        >
+          <label label="󰸉  Global — one wallpaper for all workspaces" />
+        </box>
         {actions}
+        {wallpaperEngineOptions}
         {allWallpapersDisplay}
       </box>
     );
@@ -546,6 +718,35 @@ export default ({
         (self as any).monitorName = monitorName;
         FetchWallpapers();
         FetchCurrentWallpapers(monitorName);
+
+        // Auto-discover: rescan every time the switcher is opened (Super+W), so
+        // wallpapers subscribed/added since AGS started show up without a restart.
+        self.connect("notify::visible", () => {
+          if (self.visible) {
+            FetchWallpapers();
+            FetchCurrentWallpapers(monitorName);
+          }
+        });
+
+        // Live auto-discovery: watch the wallpaper sources and rescan when their
+        // contents change — e.g. Steam finishing a Workshop download while the
+        // switcher is open, or a file dropped into ~/.config/wallpapers.
+        const watchPaths = [
+          `${GLib.get_home_dir()}/.local/share/Steam/steamapps/workshop/content/431960`,
+          // Subscription manifest: unsubscribing updates this even when Steam leaves the content
+          // folder on disk, so watching it makes removals show up live.
+          `${GLib.get_home_dir()}/.local/share/Steam/steamapps/workshop/appworkshop_431960.acf`,
+          `${GLib.get_home_dir()}/.config/wallpapers`,
+        ];
+        for (const path of watchPaths) {
+          try {
+            if (GLib.file_test(path, GLib.FileTest.EXISTS)) {
+              monitorFile(path, () => scheduleRescan());
+            }
+          } catch (err) {
+            print("WallpaperSwitcher: could not watch " + path + ": " + String(err));
+          }
+        }
 
         // Initialize selected workspace
         focusedWorkspace.subscribe(() => {

--- a/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
+++ b/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
@@ -4,6 +4,7 @@ import { Gdk } from "ags/gtk4";
 import { Astal } from "ags/gtk4";
 import Hyprland from "gi://AstalHyprland";
 import GObject from "ags/gobject";
+import Pango from "gi://Pango";
 import { createBinding, createState, createComputed, Accessor, For } from "ags";
 import { execAsync } from "ags/process";
 import { notify } from "../../../utils/notification";
@@ -23,6 +24,83 @@ import { hyprThemeConfPath } from "../../../constants/path.constants";
 const hyprland = Hyprland.get_default();
 
 const hyprCustomDir: string = "$HOME/.config/hypr/config/custom";
+
+// Wallpaper mode / primary choices (shared with the wallpaper switcher)
+export const wallpaperModeChoices = [
+  { label: "Per Workspace", value: "workspace" },
+  { label: "Global", value: "global" },
+];
+
+export const wallpaperPrimaryChoices = [
+  { label: "Workspace 1", value: "workspace1" },
+  { label: "Custom", value: "custom" },
+];
+
+// Re-resolve and apply the wallpaper that should be shown now (any type) on
+// every connected monitor. Used for mode/primary and Wallpaper Engine launch
+// options (fps/volume/mute/...), which need a fresh engine to take effect.
+export const applyCurrentWallpapers = () => {
+  execAsync([
+    "bash",
+    "-c",
+    `for m in $(hyprctl monitors -j | jq -r '.[].name'); do "$HOME/.config/hypr/wallpaper-daemon/apply-current.sh" "$m"; done`,
+  ]).catch((err) => notify({ summary: "Error", body: String(err) }));
+};
+
+// Send a live command to running Wallpaper Engine processes (no restart). Used
+// for scaling/clamp/speed/property tweaks.
+// Send a live control command to the running engine(s). The ctl script exits
+// non-zero (and prints a reason) when no engine is reachable or it rejects the
+// command, so a dead/orphaned socket no longer fails silently — we surface it.
+export const controlWE = (args: string): Promise<boolean> =>
+  execAsync([
+    "bash",
+    "-c",
+    `"$HOME/.config/hypr/wallpaper-daemon/wallpaperengine-ctl.sh" ${args}`,
+  ])
+    .then(() => true)
+    .catch(() => {
+      notify({
+        summary: "Wallpaper Engine",
+        body: `Couldn't apply "${args}" live — the engine isn't reachable. It will apply on the next reload.`,
+      });
+      return false;
+    });
+
+// Restart running engines (for changes that can't be applied live, e.g. the
+// audio capture device).
+export const restartWE = () =>
+  execAsync([
+    "bash",
+    "-c",
+    `"$HOME/.config/hypr/wallpaper-daemon/wallpaperengine-restart.sh"`,
+  ]).catch(() => {});
+
+// Try to apply a change live; if the running engine can't (socket dead, or the
+// command isn't supported by that build), fall back to a full restart so the
+// change always takes effect — no manual switch-back-and-forth needed.
+export const controlWEOrRestart = (args: string): Promise<void> =>
+  execAsync([
+    "bash",
+    "-c",
+    `"$HOME/.config/hypr/wallpaper-daemon/wallpaperengine-ctl.sh" ${args}`,
+  ])
+    .then(() => undefined)
+    .catch(() => restartWE().then(() => undefined));
+
+// Wallpaper Engine option choices (shared with the wallpaper switcher)
+export const weScalingChoices = [
+  { label: "Default", value: "default" },
+  { label: "Fill", value: "fill" },
+  { label: "Fit", value: "fit" },
+  { label: "Stretch", value: "stretch" },
+];
+
+export const weClampChoices = [
+  { label: "Clamp", value: "clamp" },
+  { label: "Border", value: "border" },
+  { label: "Repeat", value: "repeat" },
+];
 
 const setThemeFlagInConf = (
   flag: "autocolor" | "autovariant",
@@ -67,6 +145,90 @@ function addUserToInputGroup() {
     })
     .catch((err) => notify({ summary: "Error", body: err.toString() }));
 }
+
+// Audio OUTPUT devices for reactive Wallpaper Engine wallpapers (detected at
+// runtime). value = monitor source name, label = friendly description.
+const [audioSources, setAudioSources] = createState<
+  { value: string; label: string }[]
+>([]);
+
+const detectAudioSources = async () => {
+  try {
+    const out = await execAsync([
+      "bash",
+      "-c",
+      `"$HOME/.config/hypr/wallpaper-daemon/wallpaperengine-audio-devices.sh"`,
+    ]);
+    setAudioSources(
+      out
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => {
+          const [value, label] = line.split("\t");
+          return { value, label: label || value };
+        }),
+    );
+  } catch {
+    setAudioSources([]);
+  }
+};
+
+// Dropdown to pick the audio capture source (empty = system default output).
+const AudioDeviceSelector = () => (
+  <box
+    orientation={Gtk.Orientation.VERTICAL}
+    spacing={5}
+    $={() => detectAudioSources()}
+  >
+    <label
+      class="subcategory-label"
+      label="Audio Device (reactive wallpapers)"
+      halign={Gtk.Align.START}
+    />
+    <menubutton class="category-selector" halign={Gtk.Align.START}>
+      <label
+        ellipsize={Pango.EllipsizeMode.END}
+        maxWidthChars={28}
+        label={globalSettings(({ wallpaperEngine }) => {
+          const v = wallpaperEngine.audioDevice.value;
+          if (!v) return "System Default";
+          const found = audioSources.peek().find((s) => s.value === v);
+          if (found) return found.label;
+          // Friendlier fallback for a raw PulseAudio node name (the full path is
+          // huge and used to force the whole settings panel wider than it should be).
+          return v.replace(/^alsa_(output|input)\./, "").replace(/\.monitor$/, "");
+        })}
+      />
+      <popover>
+        <box orientation={Gtk.Orientation.VERTICAL} spacing={5} class="popover">
+          <button
+            class="category"
+            label="System Default"
+            onClicked={() => {
+              setGlobalSetting("wallpaperEngine.audioDevice.value", "");
+              controlWEOrRestart(`set audiodevice default`);
+            }}
+          />
+          <For each={audioSources}>
+            {(src) => (
+              <button
+                class="category"
+                label={src.label}
+                onClicked={() => {
+                  setGlobalSetting(
+                    "wallpaperEngine.audioDevice.value",
+                    src.value,
+                  );
+                  controlWEOrRestart(`set audiodevice ${src.value}`);
+                }}
+              />
+            )}
+          </For>
+        </box>
+      </popover>
+    </menubutton>
+  </box>
+);
 
 // File Manager options with display names and commands
 const fileManagerOptions = [
@@ -330,18 +492,22 @@ const BarLayoutSetting = () => {
   );
 };
 
-const Setting = ({
+export const Setting = ({
   keyChanged,
   setting,
   callBack,
   choices,
+  compact = false,
 }: {
   keyChanged: string;
   setting: AGSSetting;
   callBack?: (newValue?: any) => void;
   choices?: { label: string; value: any }[];
+  compact?: boolean;
 }) => {
-  const Title = () => <label hexpand xalign={0} label={setting.name} />;
+  const Title = () => (
+    <label hexpand={!compact} xalign={0} label={setting.name} />
+  );
 
   const SliderWidget = () => {
     const infoLabel = (
@@ -357,7 +523,12 @@ const Setting = ({
 
     const Slider = (
       <slider
-        widthRequest={globalSettings(({ leftPanel }) => leftPanel.width / 2)}
+        widthRequest={
+          compact
+            ? 140
+            : globalSettings(({ leftPanel }) => leftPanel.width / 2)
+        }
+        hexpand={!compact}
         class="slider"
         drawValue={false}
         min={setting.min}
@@ -385,6 +556,16 @@ const Setting = ({
       />
     );
 
+    if (compact) {
+      return (
+        <box spacing={5} halign={Gtk.Align.START} valign={Gtk.Align.CENTER}>
+          <Title />
+          {Slider}
+          {infoLabel}
+        </box>
+      );
+    }
+
     return (
       <box spacing={5}>
         <Title />
@@ -398,7 +579,7 @@ const Setting = ({
 
   const SwitchWidget = () => {
     const infoLabel = (
-      <label hexpand={true} label={setting.value ? "On" : "Off"} />
+      <label hexpand={false} label={setting.value ? "On" : "Off"} />
     ) as Gtk.Label;
 
     const Switch = (
@@ -413,6 +594,16 @@ const Setting = ({
       />
     );
 
+    if (compact) {
+      return (
+        <box spacing={5} halign={Gtk.Align.START} valign={Gtk.Align.CENTER}>
+          <Title />
+          {Switch}
+          {infoLabel}
+        </box>
+      );
+    }
+
     return (
       <box spacing={5}>
         <Title />
@@ -426,13 +617,19 @@ const Setting = ({
 
   const SelectWidget = () => {
     return (
-      <box orientation={Gtk.Orientation.VERTICAL} spacing={10}>
+      <box
+        orientation={Gtk.Orientation.VERTICAL}
+        spacing={10}
+        halign={compact ? Gtk.Align.START : Gtk.Align.FILL}
+      >
         <Title />
-        <box spacing={5}>
+        {/* In the settings panel (non-compact) fill the panel width so the choice
+            buttons share it; in the compact switcher keep them natural-width. */}
+        <box spacing={5} hexpand={!compact}>
           {choices &&
             choices.map((choice) => (
               <togglebutton
-                hexpand
+                hexpand={!compact}
                 label={choice.label}
                 active={globalSettings((s) => {
                   // get current value from AGSSetting from settings
@@ -670,6 +867,9 @@ export default () => {
     <box class="settings" orientation={Gtk.Orientation.VERTICAL} spacing={5}>
       <scrolledwindow
         vexpand
+        // Never scroll horizontally: constrain content to the panel width so the choice
+        // FlowBoxes wrap to a second row instead of overflowing/clipping at the edge.
+        hscrollbarPolicy={Gtk.PolicyType.NEVER}
         $={() =>
           // Initialize detection
           detectFileManagers()
@@ -782,6 +982,90 @@ export default () => {
                 },
               ]}
             />
+          </box>
+          <box
+            class={"category"}
+            orientation={Gtk.Orientation.VERTICAL}
+            spacing={16}
+          >
+            <label label="Wallpaper" halign={Gtk.Align.START} />
+            <Setting
+              keyChanged="wallpaper.mode"
+              setting={globalSettings.peek().wallpaper.mode}
+              choices={wallpaperModeChoices}
+              callBack={applyCurrentWallpapers}
+            />
+            <Setting
+              keyChanged="wallpaper.primarySource"
+              setting={globalSettings.peek().wallpaper.primarySource}
+              choices={wallpaperPrimaryChoices}
+              callBack={applyCurrentWallpapers}
+            />
+            <Setting
+              keyChanged="wallpaper.playbackSpeed"
+              setting={globalSettings.peek().wallpaper.playbackSpeed}
+              callBack={(v) => controlWE(`speed ${v}`)}
+            />
+          </box>
+          <box
+            class={"category"}
+            orientation={Gtk.Orientation.VERTICAL}
+            spacing={16}
+          >
+            <label label="Wallpaper Engine" halign={Gtk.Align.START} />
+            <Setting
+              keyChanged="wallpaperEngine.scaling"
+              setting={globalSettings.peek().wallpaperEngine.scaling}
+              choices={weScalingChoices}
+              callBack={(v) => controlWE(`scaling ${v}`)}
+            />
+            <Setting
+              keyChanged="wallpaperEngine.clamping"
+              setting={globalSettings.peek().wallpaperEngine.clamping}
+              choices={weClampChoices}
+              callBack={(v) => controlWE(`clamp ${v}`)}
+            />
+            <Setting
+              keyChanged="wallpaperEngine.fps"
+              setting={globalSettings.peek().wallpaperEngine.fps}
+              callBack={(v) => controlWE(`set fps ${v}`)}
+            />
+            <Setting
+              keyChanged="wallpaperEngine.renderScale"
+              setting={globalSettings.peek().wallpaperEngine.renderScale}
+              callBack={(v) => controlWEOrRestart(`set renderscale ${v}`)}
+            />
+            <Setting
+              keyChanged="wallpaperEngine.volume"
+              setting={globalSettings.peek().wallpaperEngine.volume}
+              callBack={(v) => controlWE(`volume ${v}`)}
+            />
+            <Setting
+              keyChanged="wallpaperEngine.mute"
+              setting={globalSettings.peek().wallpaperEngine.mute}
+              callBack={(v) => controlWE(`mute ${v ? 1 : 0}`)}
+            />
+            <Setting
+              keyChanged="wallpaperEngine.noAutomute"
+              setting={globalSettings.peek().wallpaperEngine.noAutomute}
+              callBack={(v) => controlWE(`set noautomute ${v ? 1 : 0}`)}
+            />
+            <Setting
+              keyChanged="wallpaperEngine.disableMouse"
+              setting={globalSettings.peek().wallpaperEngine.disableMouse}
+              callBack={(v) => controlWE(`set disablemouse ${v ? 1 : 0}`)}
+            />
+            <Setting
+              keyChanged="wallpaperEngine.disableParallax"
+              setting={globalSettings.peek().wallpaperEngine.disableParallax}
+              callBack={(v) => controlWE(`set disableparallax ${v ? 1 : 0}`)}
+            />
+            <Setting
+              keyChanged="wallpaperEngine.noFullscreenPause"
+              setting={globalSettings.peek().wallpaperEngine.noFullscreenPause}
+              callBack={(v) => controlWE(`set nofullscreenpause ${v ? 1 : 0}`)}
+            />
+            <AudioDeviceSelector />
           </box>
           <box
             class={"category"}

--- a/.config/hypr/maintenance/components/wallpaperengine.py
+++ b/.config/hypr/maintenance/components/wallpaperengine.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Install linux-wallpaperengine (the renderer behind the Wallpaper Engine integration).
+
+The daemon (``~/.config/hypr/wallpaper-daemon/wallpaperengine.sh``) and the AGS selector
+depend on fork-only features (a live control socket, ``--render-scale`` supersampling and
+native 3D ``.mdl`` model rendering), so this builds from source rather than using the
+upstream AUR package. The binary is placed where the daemon looks for it:
+
+    ~/linux-wallpaperengine/build/output/linux-wallpaperengine
+
+Source selection is asked at install time (no silent default). Environment variables
+override the prompt for non-interactive / scripted installs:
+
+    WPE_LOCAL_REPO   path to an existing local checkout (built in place, symlinked into place)
+    WPE_REPO_URL     remote git URL to clone
+    WPE_REPO_REF     branch / tag / commit for WPE_REPO_URL (default: the repo's default branch)
+    WPE_FORCE=1      replace an existing ~/linux-wallpaperengine (backed up to .bak) without asking
+    WPE_SKIP=1       skip this step entirely
+
+A build failure is reported as a warning and does NOT abort the rest of the installation.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Optional
+
+if __package__ in (None, ""):
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from components.utils import run_cmd, run_shell, fzf_select
+    from components.presentation import print_step, print_success, print_warning
+else:
+    from .utils import run_cmd, run_shell, fzf_select
+    from .presentation import print_step, print_success, print_warning
+
+# The ArchEclipse Wallpaper Engine fork + the branch that carries the integration features.
+# Offered as a menu choice; never used unless the user explicitly picks it (or sets the env vars).
+FORK_URL = "https://github.com/beingsuz/linux-wallpaperengine.git"
+FORK_REF = "feat/better-wallpaper-support"
+
+# Where the daemon expects the binary: ~/linux-wallpaperengine/build/output/linux-wallpaperengine
+DEST = Path.home() / "linux-wallpaperengine"
+
+# Arch build dependencies. CEF is downloaded automatically by CMake (CMakeModules/DownloadCEF.cmake),
+# so it is not listed here. base-devel covers make/gcc/etc.
+BUILD_DEPS: list[str] = [
+    "base-devel",
+    "cmake",
+    "git",
+    "pkgconf",
+    "glew",
+    "glfw",
+    "glm",
+    "freeglut",
+    "sdl2",
+    "lz4",
+    "zlib",
+    "ffmpeg",
+    "mpv",
+    "libpulse",
+    "freetype2",
+    "fftw",
+    "gmp",
+    "libx11",
+    "libxrandr",
+    "libxinerama",
+    "libxcursor",
+    "libxi",
+    "libxxf86vm",
+    "wayland",
+    "wayland-protocols",
+    "libglvnd",
+    "mesa",
+]
+
+
+# --------------------------------------------------------------------------- source selection
+
+def _env(name: str) -> Optional[str]:
+    value = os.environ.get(name)
+    value = value.strip() if value else ""
+    return value or None
+
+
+def _truthy(name: str) -> bool:
+    return (os.environ.get(name) or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _choose_source() -> Optional[tuple[str, str, Optional[str]]]:
+    """Return (kind, location, ref) where kind is 'remote' or 'local', or None to skip.
+
+    Precedence: WPE_SKIP -> WPE_LOCAL_REPO -> WPE_REPO_URL -> interactive prompt.
+    """
+    if _truthy("WPE_SKIP"):
+        print_warning("WPE_SKIP set — skipping Wallpaper Engine.")
+        return None
+
+    local = _env("WPE_LOCAL_REPO")
+    if local:
+        return ("local", str(Path(local).expanduser()), None)
+
+    url = _env("WPE_REPO_URL")
+    if url:
+        return ("remote", url, _env("WPE_REPO_REF"))
+
+    if not sys.stdin.isatty():
+        print_warning(
+            "No TTY and no WPE_* override set — skipping Wallpaper Engine. "
+            "Set WPE_REPO_URL or WPE_LOCAL_REPO to install non-interactively."
+        )
+        return None
+
+    options = [
+        f"ArchEclipse fork  ({FORK_URL.split('://')[-1]} @ {FORK_REF})",
+        "Custom remote repository (enter a git URL)",
+        "Local repository (enter a path to an existing checkout)",
+        "Skip Wallpaper Engine",
+    ]
+    print("Choose where to get linux-wallpaperengine from:")
+    selection = fzf_select(options)
+    if not selection or selection.startswith("Skip"):
+        print_warning("No source selected — skipping Wallpaper Engine.")
+        return None
+
+    if selection.startswith("ArchEclipse fork"):
+        return ("remote", FORK_URL, FORK_REF)
+
+    if selection.startswith("Custom remote"):
+        url = input("  Git URL: ").strip()
+        if not url:
+            print_warning("No URL entered — skipping Wallpaper Engine.")
+            return None
+        ref = input("  Branch / tag / commit (leave blank for the default branch): ").strip()
+        return ("remote", url, ref or None)
+
+    # Local repository
+    path = input("  Path to the local checkout: ").strip()
+    if not path:
+        print_warning("No path entered — skipping Wallpaper Engine.")
+        return None
+    return ("local", str(Path(path).expanduser()), None)
+
+
+# --------------------------------------------------------------------------- dependencies
+
+def _install_build_deps(aur_helper: str) -> None:
+    print_step("*", "Installing build dependencies")
+    # Mirror packages.py: feed targets on stdin so the helper resolves official + AUR repos.
+    run_cmd(
+        [aur_helper, "-S", "--needed", "-"],
+        input_text="\n".join(BUILD_DEPS),
+    )
+
+
+# --------------------------------------------------------------------------- source preparation
+
+def _confirm_overwrite() -> bool:
+    if _truthy("WPE_FORCE"):
+        return True
+    if not sys.stdin.isatty():
+        return False
+    answer = input(
+        f"  {DEST} already exists. Replace it (a backup is kept as .bak)? [y/N]: "
+    ).strip().lower()
+    return answer.startswith("y")
+
+
+def _backup_dest() -> None:
+    backup = DEST.with_name(DEST.name + ".bak")
+    if backup.is_symlink() or backup.exists():
+        if backup.is_dir() and not backup.is_symlink():
+            shutil.rmtree(backup)
+        else:
+            backup.unlink()
+    shutil.move(str(DEST), str(backup))
+    print_warning(f"Existing checkout moved to {backup}")
+
+
+def _prepare_source(kind: str, location: str, ref: Optional[str]) -> Optional[Path]:
+    """Make sure the source tree exists at DEST and return its real build directory."""
+    if kind == "local":
+        src = Path(location)
+        if not (src / "CMakeLists.txt").is_file():
+            print_warning(f"'{src}' does not look like a linux-wallpaperengine checkout — skipping.")
+            return None
+        if src.resolve() == DEST.resolve():
+            return DEST
+        # Point ~/linux-wallpaperengine at the local checkout so the daemon finds the build.
+        if DEST.exists() or DEST.is_symlink():
+            if not _confirm_overwrite():
+                print_warning(f"Keeping existing {DEST}; building it instead of the local path.")
+                return DEST
+            _backup_dest()
+        DEST.symlink_to(src, target_is_directory=True)
+        print_success(f"Linked {DEST} -> {src}")
+        return src
+
+    # remote
+    if DEST.exists() or DEST.is_symlink():
+        if not _confirm_overwrite():
+            print_warning(f"{DEST} already exists — rebuilding it (source override ignored).")
+            return DEST
+        _backup_dest()
+
+    print_step("*", f"Cloning {location}" + (f" ({ref})" if ref else ""))
+    clone = ["git", "clone", "--depth", "1", location, str(DEST)]
+    if ref:
+        # ref must be a branch or tag (shallow clone can't target an arbitrary commit).
+        clone[4:4] = ["--branch", ref]
+    run_cmd(clone)
+    return DEST
+
+
+# --------------------------------------------------------------------------- build
+
+def _build(repo_dir: Path) -> None:
+    build_dir = repo_dir / "build"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    print_step("*", "Configuring (CMake — this downloads CEF on first run)")
+    run_cmd(["cmake", "-DCMAKE_BUILD_TYPE=Release", ".."], cwd=build_dir)
+    print_step("*", "Compiling (this can take a while)")
+    jobs = str(os.cpu_count() or 1)
+    run_cmd(["cmake", "--build", ".", "-j", jobs], cwd=build_dir)
+
+    binary = build_dir / "output" / "linux-wallpaperengine"
+    if not binary.is_file():
+        raise RuntimeError(f"build finished but {binary} is missing")
+    print_success(f"Built {binary}")
+
+
+def _print_steam_notice() -> None:
+    print("")
+    print_warning(
+        "Wallpaper Engine assets come from Steam: you must OWN and install Wallpaper Engine "
+        "(via Steam, Proton/Windows build) so its Workshop items appear under "
+        "~/.local/share/Steam/steamapps/workshop/content/431960. The renderer itself is now "
+        "built; subscribe to wallpapers in Steam, then pick them with Super+W."
+    )
+
+
+# --------------------------------------------------------------------------- entrypoint
+
+def install_wallpaper_engine(aur_helper: str = "yay") -> None:
+    run_shell("figlet 'WALLPAPER ENGINE' -f slant | lolcat", check=False)
+
+    try:
+        source = _choose_source()
+        if source is None:
+            return
+        kind, location, ref = source
+        _install_build_deps(aur_helper)
+        repo_dir = _prepare_source(kind, location, ref)
+        if repo_dir is None:
+            return
+        _build(repo_dir)
+        _print_steam_notice()
+    except Exception as exc:  # noqa: BLE001 — never abort the whole install for this optional step
+        print_warning(f"Wallpaper Engine setup failed: {exc}")
+        print_warning(
+            "You can finish it later: install the deps, then "
+            "`cd ~/linux-wallpaperengine && cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build`."
+        )
+
+
+def main() -> None:
+    aur_helper = sys.argv[1] if len(sys.argv) > 1 else "yay"
+    install_wallpaper_engine(aur_helper)
+
+
+if __name__ == "__main__":
+    main()

--- a/.config/hypr/maintenance/components/wallpaperengine.py
+++ b/.config/hypr/maintenance/components/wallpaperengine.py
@@ -215,10 +215,13 @@ def _prepare_source(kind: str, location: str, ref: Optional[str]) -> Optional[Pa
         _backup_dest()
 
     print_step("*", f"Cloning {location}" + (f" ({ref})" if ref else ""))
-    clone = ["git", "clone", "--depth", "1", location, str(DEST)]
+    # --recurse-submodules: the engine vendors glslang/SPIRV-Cross/quickjs/kissfft/argparse as
+    # submodules under src/External; without them CMake's add_subdirectory aborts the configure.
+    clone = ["git", "clone", "--depth", "1", "--recurse-submodules"]
     if ref:
         # ref must be a branch or tag (shallow clone can't target an arbitrary commit).
-        clone[4:4] = ["--branch", ref]
+        clone += ["--branch", ref]
+    clone += [location, str(DEST)]
     run_cmd(clone)
     return DEST
 
@@ -226,6 +229,12 @@ def _prepare_source(kind: str, location: str, ref: Optional[str]) -> Optional[Pa
 # --------------------------------------------------------------------------- build
 
 def _build(repo_dir: Path) -> None:
+    # Repair a checkout cloned without submodules (older installer, or a manual clone): fetch them
+    # before configuring so CMake finds the vendored deps under src/External. Idempotent.
+    if (repo_dir / ".gitmodules").is_file():
+        print_step("*", "Fetching git submodules")
+        run_cmd(["git", "-C", str(repo_dir), "submodule", "update", "--init", "--recursive"])
+
     build_dir = repo_dir / "build"
     build_dir.mkdir(parents=True, exist_ok=True)
     print_step("*", "Configuring (CMake — this downloads CEF on first run)")

--- a/.config/hypr/maintenance/components/wallpaperengine.py
+++ b/.config/hypr/maintenance/components/wallpaperengine.py
@@ -146,13 +146,22 @@ def _choose_source() -> Optional[tuple[str, str, Optional[str]]]:
 
 # --------------------------------------------------------------------------- dependencies
 
+def _unsatisfied(packages: list[str]) -> list[str]:
+    # `pacman -T` prints only deps not already satisfied, honoring `provides`: a drop-in such as
+    # zlib-ng-compat (provides zlib) or sdl2-compat (provides sdl2) counts as met and is dropped, so
+    # we never force a conflicting replacement that breaks lib32-* dependents. Groups pass through.
+    result = run_cmd(["pacman", "-T", *packages], check=False, capture_output=True)
+    return [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
+
+
 def _install_build_deps(aur_helper: str) -> None:
     print_step("*", "Installing build dependencies")
-    # Mirror packages.py: feed targets on stdin so the helper resolves official + AUR repos.
-    run_cmd(
-        [aur_helper, "-S", "--needed", "-"],
-        input_text="\n".join(BUILD_DEPS),
-    )
+    missing = _unsatisfied(BUILD_DEPS)
+    if not missing:
+        print_success("All build dependencies already satisfied.")
+        return
+    # Only install what's genuinely missing; feed on stdin so the helper resolves official + AUR.
+    run_cmd([aur_helper, "-S", "--needed", "-"], input_text="\n".join(missing))
 
 
 # --------------------------------------------------------------------------- source preparation

--- a/.config/hypr/maintenance/install.py
+++ b/.config/hypr/maintenance/install.py
@@ -63,19 +63,25 @@ def load_components(maintenance_dir: Path) -> dict[str, Any]:
         "defaults": importlib.import_module("components.defaults"),
         "sddm": importlib.import_module("components.sddm"),
         "wallpapers": importlib.import_module("components.wallpapers"),
+        "wallpaperengine": importlib.import_module("components.wallpaperengine"),
         "plugins": importlib.import_module("components.plugins"),
         "tweaks": importlib.import_module("components.tweaks"),
     }
     return components
 
 
-def parse_branch(argv: list[str]) -> str:
+def parse_options(argv: list[str]) -> tuple[str, str]:
     """
     Branch precedence:
     - `--branch/-b <name>`
     - legacy positional `<branch>` (argv[1])
     - env `ARCHECLIPSE_BRANCH`
     - default: `master`
+
+    Repository precedence (URL or GitHub `owner/name`, for testing forks):
+    - `--repo/-r <repo>`
+    - env `ARCHECLIPSE_REPO`
+    - default: `AymanLyesri/ArchEclipse`
     """
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument(
@@ -83,6 +89,12 @@ def parse_branch(argv: list[str]) -> str:
         "--branch",
         default=None,
         help="ArchEclipse git branch to clone (default: master)",
+    )
+    parser.add_argument(
+        "-r",
+        "--repo",
+        default=None,
+        help="ArchEclipse git repository, URL or owner/name (default: AymanLyesri/ArchEclipse)",
     )
     parser.add_argument(
         "legacy_branch",
@@ -94,12 +106,17 @@ def parse_branch(argv: list[str]) -> str:
     args = parser.parse_args(argv[1:])
 
     if args.branch:
-        return str(args.branch)
-    if args.legacy_branch:
-        return str(args.legacy_branch)
-    if os.environ.get("ARCHECLIPSE_BRANCH"):
-        return str(os.environ["ARCHECLIPSE_BRANCH"])
-    return "master"
+        branch = str(args.branch)
+    elif args.legacy_branch:
+        branch = str(args.legacy_branch)
+    else:
+        branch = os.environ.get("ARCHECLIPSE_BRANCH", "master")
+
+    repo = str(args.repo) if args.repo else os.environ.get("ARCHECLIPSE_REPO", "AymanLyesri/ArchEclipse")
+    if "://" not in repo:
+        repo = f"https://github.com/{repo}.git"
+
+    return branch, repo
 
 
 def main() -> None:
@@ -118,9 +135,9 @@ def main() -> None:
         print(f"Repository already exists at {conf_dir}; overwriting")
         shutil.rmtree(conf_dir)
 
-    branch = parse_branch(sys.argv)
+    branch, repo = parse_options(sys.argv)
 
-    print("Cloning ArchEclipse repository (latest commit only)...")
+    print(f"Cloning ArchEclipse repository from {repo} (latest commit only)...")
     run_cmd(
         [
             "git",
@@ -130,7 +147,7 @@ def main() -> None:
             "--single-branch",
             "--branch",
             branch,
-            "https://github.com/AymanLyesri/ArchEclipse.git",
+            repo,
             str(conf_dir),
         ]
     )
@@ -193,6 +210,11 @@ def main() -> None:
             ),
             presentation.PlannedStep(
                 "wallpapers", "Setting up wallpapers", default_choice="y"
+            ),
+            presentation.PlannedStep(
+                "wallpaper_engine",
+                "Installing Wallpaper Engine renderer (builds linux-wallpaperengine)",
+                default_choice="y",
             ),
             presentation.PlannedStep(
                 "plugins", "Installing plugins", default_choice="y"
@@ -296,6 +318,16 @@ def main() -> None:
         "Setting up wallpapers",
         modules["wallpapers"].main,
         run=plan["wallpapers"],
+    )
+
+    presentation.print_section_header("WALLPAPER ENGINE")
+    presentation.execute_planned_step(
+        "*",
+        "Installing Wallpaper Engine renderer (linux-wallpaperengine)",
+        lambda helper=aur_helper: modules["wallpaperengine"].install_wallpaper_engine(
+            helper
+        ),
+        run=plan["wallpaper_engine"],
     )
 
     presentation.print_section_header("PLUGINS & TWEAKS")

--- a/.config/hypr/scripts-c/wallpaper-loop.c
+++ b/.config/hypr/scripts-c/wallpaper-loop.c
@@ -280,6 +280,109 @@ bool get_wallpaper_for_workspace(const char* monitor, int workspace_id, char* wa
 }
 
 /*
+ * Read a value for an arbitrary key (e.g. "w-3", "global", "primary") from a
+ * monitor's defaults.conf. Returns true if the key line exists.
+ */
+bool get_config_value(const char* monitor, const char* key, char* out, size_t size) {
+    char config_path[MAX_PATH_LEN];
+    snprintf(config_path, sizeof(config_path),
+             "%s/wallpaper-daemon/config/%s/defaults.conf", hypr_dir, monitor);
+
+    FILE* fp = fopen(config_path, "r");
+    if (!fp) {
+        return false;
+    }
+
+    char key_eq[64];
+    snprintf(key_eq, sizeof(key_eq), "%s=", key);
+
+    char line[MAX_LINE_LEN];
+    bool found = false;
+    while (fgets(line, sizeof(line), fp)) {
+        line[strcspn(line, "\n")] = 0;
+        if (strncmp(line, key_eq, strlen(key_eq)) == 0) {
+            strncpy(out, line + strlen(key_eq), size - 1);
+            out[size - 1] = '\0';
+            found = true;
+            break;
+        }
+    }
+
+    fclose(fp);
+    return found;
+}
+
+/*
+ * Read a string setting from the AGS settings.json using jq, falling back to
+ * the given default when the file/key is missing.
+ */
+void read_setting(const char* jq_filter, const char* fallback, char* out, size_t n) {
+    const char* home = getenv("HOME");
+    if (!home) home = "";
+
+    char cmd[1024];
+    snprintf(cmd, sizeof(cmd),
+             "jq -r '(%s) // \"%s\"' '%s/.config/ags/cache/settings/settings.json' 2>/dev/null",
+             jq_filter, fallback, home);
+
+    char* o = exec_command(cmd);
+    if (!o) {
+        strncpy(out, fallback, n - 1);
+        out[n - 1] = '\0';
+        return;
+    }
+
+    o[strcspn(o, "\n")] = 0;
+    if (o[0] == '\0' || strcmp(o, "null") == 0) {
+        strncpy(out, fallback, n - 1);
+    } else {
+        strncpy(out, o, n - 1);
+    }
+    out[n - 1] = '\0';
+}
+
+/*
+ * Resolve the wallpaper that should be shown for a monitor/workspace, honoring
+ * the configured mode (Global vs Per Workspace) and the primary fallback.
+ * Writes an empty string to out when nothing is configured.
+ */
+void resolve_wallpaper(const char* monitor, int workspace_id, char* out, size_t size) {
+    char mode[32];
+    read_setting(".wallpaper.mode.value", "workspace", mode, sizeof(mode));
+
+    out[0] = '\0';
+    bool got = false;
+
+    if (strcmp(mode, "global") == 0) {
+        if (get_config_value(monitor, "global", out, size) && out[0] != '\0') {
+            got = true;
+        }
+    } else {
+        char key[32];
+        snprintf(key, sizeof(key), "w-%d", workspace_id);
+        if (get_config_value(monitor, key, out, size) && out[0] != '\0') {
+            got = true;
+        }
+    }
+
+    if (!got) {
+        /* Primary fallback: explicit custom primary, else workspace 1. */
+        char src[32];
+        read_setting(".wallpaper.primarySource.value", "workspace1", src, sizeof(src));
+
+        if (strcmp(src, "custom") == 0 &&
+            get_config_value(monitor, "primary", out, size) && out[0] != '\0') {
+            got = true;
+        }
+        if (!got) {
+            if (!(get_config_value(monitor, "w-1", out, size) && out[0] != '\0')) {
+                out[0] = '\0';
+            }
+        }
+    }
+}
+
+/*
  * Get active workspace ID for a monitor
  * Parses JSON output from hyprctl monitors
  * Searches for monitor by name, then extracts activeWorkspace.id
@@ -430,21 +533,6 @@ bool is_hyprpaper_running() {
     return system("pgrep -x hyprpaper >/dev/null 2>&1") == 0;
 }
 
-/* Check if wallpaper should be rendered via mpvpaper */
-bool is_media_wallpaper(const char* wallpaper) {
-    if (!wallpaper) {
-        return false;
-    }
-
-    const char* dot = strrchr(wallpaper, '.');
-    if (!dot || *(dot + 1) == '\0') {
-        return false;
-    }
-
-    const char* ext = dot + 1;
-    return strcasecmp(ext, "gif") == 0 || strcasecmp(ext, "mp4") == 0 || strcasecmp(ext, "webm") == 0;
-}
-
 /* Kill any running wallpaper script instances */
 void kill_wallpaper_script() {
     char cmd[MAX_PATH_LEN];
@@ -488,13 +576,14 @@ void change_wallpaper() {
         }
         
         char wallpaper[MAX_PATH_LEN];
-        if (!get_wallpaper_for_workspace(monitor, workspace_id, wallpaper, sizeof(wallpaper))) {
-            char error_msg[512];
-            snprintf(error_msg, sizeof(error_msg), "No wallpaper config for '%s' workspace %d", monitor, workspace_id);
-            notify_error("change_wallpaper", error_msg);
+        resolve_wallpaper(monitor, workspace_id, wallpaper, sizeof(wallpaper));
+        if (wallpaper[0] == '\0') {
+            /* Nothing configured and no primary fallback; leave current wallpaper. */
+            state->previous_workspace_id = workspace_id;
+            state->initialized = true;
             continue;
         }
-        
+
         /* Skip if wallpaper path unchanged (workspace switch but same wallpaper) */
         if (state->initialized && strcmp(wallpaper, state->current_wallpaper) == 0) {
             state->previous_workspace_id = workspace_id;
@@ -518,14 +607,10 @@ void change_wallpaper() {
         }
         
         kill_wallpaper_script();
-        
-        /* Execute wallpaper change script */
+
+        /* Hand off to the renderer dispatcher (decides WE / video / image). */
         char cmd[MAX_PATH_LEN * 2];
-        if (is_media_wallpaper(expanded_wallpaper)) {
-            snprintf(cmd, sizeof(cmd), "%s/wallpaper-daemon/mpvpaper.sh '%s' '%s' &", hypr_dir, monitor, expanded_wallpaper);
-        } else {
-            snprintf(cmd, sizeof(cmd), "%s/wallpaper-daemon/hyprpaper.sh '%s' '%s' &", hypr_dir, monitor, expanded_wallpaper);
-        }
+        snprintf(cmd, sizeof(cmd), "%s/wallpaper-daemon/dispatch.sh '%s' '%s' &", hypr_dir, monitor, expanded_wallpaper);
         system(cmd);
         
         /* Update monitor state */

--- a/.config/hypr/scripts/ags-watchdog.sh
+++ b/.config/hypr/scripts/ags-watchdog.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# ags-watchdog.sh <ags-bin>
+#
+# Keeps the AGS shell alive. ArchEclipse's GTK4 shell occasionally dies with a
+# `gdk_surface_get_display` assertion (a surface lifecycle race, seen alongside the
+# network applet's GtkStack churn). Rather than leave the desktop without a bar/panels
+# until a manual relaunch, respawn it automatically.
+#
+# Stops cleanly when ags-bin exits 0 (e.g. `ags quit` during a config reload) or when
+# the watchdog itself is terminated (so a deliberate restart isn't fought). A crash
+# (non-zero exit) is respawned, with a back-off if it's crash-looping.
+
+BIN="$1"
+[ -x "$BIN" ] || { echo "ags-watchdog: '$BIN' not executable" >&2; exit 1; }
+
+child=0
+trap 'kill "$child" 2>/dev/null; exit 0' TERM INT
+
+fails=0
+window=$(date +%s)
+
+while true; do
+    "$BIN" &
+    child=$!
+    wait "$child"
+    code=$?
+
+    # Clean shutdown (ags quit) -> stop respawning.
+    [ "$code" -eq 0 ] && exit 0
+
+    now=$(date +%s)
+    if [ $((now - window)) -ge 30 ]; then
+        fails=0
+        window=$now
+    fi
+    fails=$((fails + 1))
+
+    if [ "$fails" -ge 6 ]; then
+        notify-send -u critical "AGS" "Crashed ${fails}× in 30s — backing off 20s" 2>/dev/null
+        sleep 20
+        fails=0
+        window=$(date +%s)
+    fi
+    sleep 1
+done

--- a/.config/hypr/scripts/compile-run-binaries.sh
+++ b/.config/hypr/scripts/compile-run-binaries.sh
@@ -19,7 +19,10 @@ ags bundle "$CONFIG_DIR/ags/app.tsx" "$AGS_TMP/ags-bin"
 pkill -f "wallpaper-loop" 2>/dev/null
 
 "$TMP/wallpaper-loop" &
-"$AGS_TMP/ags-bin" > "$AGS_TMP/ags-bin.log" 2>&1 &
+# Launch AGS under a watchdog so a GTK4 surface-assertion crash self-heals instead of
+# leaving the desktop without bar/panels until a manual relaunch.
+chmod +x "$HOME/.config/hypr/scripts/ags-watchdog.sh" 2>/dev/null
+"$HOME/.config/hypr/scripts/ags-watchdog.sh" "$AGS_TMP/ags-bin" > "$AGS_TMP/ags-bin.log" 2>&1 &
 
 # Run immediately once
 "$TMP/battery-check" &

--- a/.config/hypr/wallpaper-daemon/apply-current.sh
+++ b/.config/hypr/wallpaper-daemon/apply-current.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# apply-current.sh <monitor>
+#
+# Resolves and applies the wallpaper that *should* be shown on a monitor right
+# now, honoring the configured mode (Global vs Per Workspace) and the primary
+# fallback. Mirrors resolve_wallpaper() in wallpaper-loop.c. Used by the UI to
+# apply changes (e.g. switching mode) immediately for any wallpaper type.
+
+hyprDir="$HOME/.config/hypr"
+monitor="$1"
+[ -z "$monitor" ] && { echo "Usage: apply-current.sh <monitor>" >&2; exit 1; }
+
+conf="$hyprDir/wallpaper-daemon/config/$monitor/defaults.conf"
+[ -f "$conf" ] || exit 0
+
+settings="$HOME/.config/ags/cache/settings/settings.json"
+read_key() { grep "^$1=" "$conf" | cut -d'=' -f2- | head -n 1; }
+
+mode="workspace"
+src="workspace1"
+if command -v jq >/dev/null 2>&1 && [ -f "$settings" ]; then
+    m="$(jq -r '(.wallpaper.mode.value) // "workspace"' "$settings" 2>/dev/null)"
+    [ -n "$m" ] && [ "$m" != "null" ] && mode="$m"
+    s="$(jq -r '(.wallpaper.primarySource.value) // "workspace1"' "$settings" 2>/dev/null)"
+    [ -n "$s" ] && [ "$s" != "null" ] && src="$s"
+fi
+
+ws="$(hyprctl monitors -j | jq -r --arg m "$monitor" \
+    '.[] | select(.name == $m) | .activeWorkspace.id')"
+
+wallpaper=""
+if [ "$mode" = "global" ]; then
+    wallpaper="$(read_key global)"
+else
+    wallpaper="$(read_key "w-${ws}")"
+fi
+
+if [ -z "$wallpaper" ]; then
+    [ "$src" = "custom" ] && wallpaper="$(read_key primary)"
+    [ -z "$wallpaper" ] && wallpaper="$(read_key w-1)"
+fi
+
+[ -z "$wallpaper" ] && exit 0
+
+exec "$hyprDir/wallpaper-daemon/dispatch.sh" "$monitor" "$wallpaper"

--- a/.config/hypr/wallpaper-daemon/dispatch.sh
+++ b/.config/hypr/wallpaper-daemon/dispatch.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# dispatch.sh <monitor> <wallpaper>
+#
+# Single source of truth for picking a wallpaper's renderer:
+#   Steam Workshop item -> Wallpaper Engine, gif/mp4/webm -> mpvpaper, else -> hyprpaper.
+# Called by wallpaper-loop.c, apply-current.sh and set-wallpaper.sh so the decision lives in one place.
+
+hyprDir="$HOME/.config/hypr"
+daemon="$hyprDir/wallpaper-daemon"
+monitor="$1"
+wallpaper="$2"
+[ -n "$monitor" ] && [ -n "$wallpaper" ] || { echo "usage: dispatch.sh <monitor> <wallpaper>" >&2; exit 1; }
+
+case "$wallpaper" in
+    */workshop/content/431960/*)
+        exec "$daemon/wallpaperengine.sh" "$monitor" "$wallpaper"
+        ;;
+    *)
+        case "$(printf '%s' "${wallpaper##*.}" | tr '[:upper:]' '[:lower:]')" in
+            gif|mp4|webm) exec "$daemon/mpvpaper.sh" "$monitor" "$wallpaper" ;;
+            *)            exec "$daemon/hyprpaper.sh" "$monitor" "$wallpaper" ;;
+        esac
+        ;;
+esac

--- a/.config/hypr/wallpaper-daemon/hyprpaper.sh
+++ b/.config/hypr/wallpaper-daemon/hyprpaper.sh
@@ -17,5 +17,12 @@ for pid in $(pgrep -x mpvpaper); do
     fi
 done
 
+# Stop any linux-wallpaperengine instance bound to this monitor
+for pid in $(pgrep -f "linux-wallpaperengine"); do
+    if tr '\0' ' ' < "/proc/$pid/cmdline" | grep -q -- "--screen-root $monitor"; then
+        kill "$pid" 2>/dev/null
+    fi
+done
+
 # Set wallpaper theme
 "$hyprdir/theme/scripts/wal-theme.sh" "$wallpaper"

--- a/.config/hypr/wallpaper-daemon/mpvpaper.sh
+++ b/.config/hypr/wallpaper-daemon/mpvpaper.sh
@@ -20,8 +20,23 @@ for pid in $(pgrep -x mpvpaper); do
     fi
 done
 
+# Stop any linux-wallpaperengine instance bound to this monitor
+for pid in $(pgrep -f "linux-wallpaperengine"); do
+    if tr '\0' ' ' < "/proc/$pid/cmdline" | grep -q -- "--screen-root $monitor"; then
+        kill "$pid" 2>/dev/null
+    fi
+done
+
+# Read playback speed from settings (defaults to 1 = normal).
+settings="$HOME/.config/ags/cache/settings/settings.json"
+speed="1"
+if command -v jq >/dev/null 2>&1 && [ -f "$settings" ]; then
+    s="$(jq -r '(.wallpaper.playbackSpeed.value) // 1' "$settings" 2>/dev/null)"
+    [ -n "$s" ] && [ "$s" != "null" ] && speed="$s"
+fi
+
 # Start mpvpaper in background for animated/video wallpapers
-nohup mpvpaper -o "no-audio --loop --fs --panscan=1.0" "$monitor" "$wallpaper" >/dev/null 2>&1 &
+nohup mpvpaper -o "no-audio --loop --fs --panscan=1.0 --speed=$speed" "$monitor" "$wallpaper" >/dev/null 2>&1 &
 
 sleep 1 # Wait for wallpaper to be set (removes stuttering)
 

--- a/.config/hypr/wallpaper-daemon/reload.sh
+++ b/.config/hypr/wallpaper-daemon/reload.sh
@@ -6,6 +6,7 @@ hyprDir=$HOME/.config/hypr # hypr directory
 # Kill existing hyprpaper and auto.sh to prevent memory leak
 killall hyprpaper 2>/dev/null
 pkill -f "wallpaper-loop" 2>/dev/null
+pkill -f "linux-wallpaperengine" 2>/dev/null
 
 nohup hyprpaper > /dev/null 2>&1 &
 

--- a/.config/hypr/wallpaper-daemon/set-wallpaper.sh
+++ b/.config/hypr/wallpaper-daemon/set-wallpaper.sh
@@ -1,12 +1,22 @@
 #!/bin/bash
+#
+# set-wallpaper.sh <slot> <monitor> [wallpaper]
+#
+# <slot> is one of:
+#   <number>  - assign to that workspace      (stored as w-<number>=)
+#   global    - the single Global-mode wallpaper (stored as global=)
+#   primary   - the fallback wallpaper        (stored as primary=)
+#
+# Whether the wallpaper is rendered immediately depends on the configured
+# wallpaper mode (Global vs Per Workspace) and the currently active workspace.
 
 hyprDir="$HOME/.config/hypr"
-workspace_id="$1"
+slot="$1"
 monitor="$2"
 wallpaper="$3"
 
-if [ -z "$workspace_id" ] || [ -z "$monitor" ]; then
-    echo "Usage: set-wallpaper.sh <workspace_id> <monitor> [wallpaper]"
+if [ -z "$slot" ] || [ -z "$monitor" ]; then
+    echo "Usage: set-wallpaper.sh <slot|global|primary> <monitor> [wallpaper]"
     exit 1
 fi
 
@@ -24,27 +34,60 @@ if [ ! -f "$current_config" ]; then
     exit 1
 fi
 
+# Map the slot to its config key.
+case "$slot" in
+    global) key="global" ;;
+    primary) key="primary" ;;
+    *) key="w-${slot}" ;;
+esac
+
+read_key() { grep "^$1=" "$current_config" | cut -d'=' -f2- | head -n 1; }
+
+# Apply a wallpaper using the appropriate backend for its type (see dispatch.sh).
+dispatch() {
+    "$hyprDir/wallpaper-daemon/dispatch.sh" "$monitor" "$1" &
+}
+
+# Read the configured wallpaper mode (default: per-workspace).
+settings="$HOME/.config/ags/cache/settings/settings.json"
+mode="workspace"
+if command -v jq >/dev/null 2>&1 && [ -f "$settings" ]; then
+    m="$(jq -r '(.wallpaper.mode.value) // "workspace"' "$settings" 2>/dev/null)"
+    [ -n "$m" ] && mode="$m"
+fi
+
 current_workspace="$(hyprctl monitors -j | jq -r --arg monitor "$monitor" '.[] | select(.name == $monitor) | .activeWorkspace.id')"
 
-if ! grep -q "^w-${workspace_id}=" "$current_config"; then
-    echo "w-${workspace_id}=" >> "$current_config"
+# Ensure the key exists so the upsert below can replace it.
+if ! grep -q "^${key}=" "$current_config"; then
+    echo "${key}=" >> "$current_config"
 fi
 
-old_wallpaper="$(grep "^w-${workspace_id}=" "$current_config" | cut -d'=' -f2- | head -n 1)"
-if [ "$old_wallpaper" = "$wallpaper" ]; then
-    echo "Wallpaper is already set to $wallpaper"
-    exit 0
-fi
+old_wallpaper="$(read_key "$key")"
 
-if [ "$workspace_id" = "$current_workspace" ]; then
-    wallpaper_ext="${wallpaper##*.}"
-    wallpaper_ext="$(printf '%s' "$wallpaper_ext" | tr '[:upper:]' '[:lower:]')"
-    
-    if [ "$wallpaper_ext" = "gif" ] || [ "$wallpaper_ext" = "mp4" ] || [ "$wallpaper_ext" = "webm" ]; then
-        "$hyprDir/wallpaper-daemon/mpvpaper.sh" "$monitor" "$wallpaper" &
-    else
-        "$hyprDir/wallpaper-daemon/hyprpaper.sh" "$monitor" "$wallpaper" &
+# Decide whether the change is visible right now and should be rendered.
+render=false
+if [ "$mode" = "global" ]; then
+    if [ "$slot" = "global" ]; then
+        render=true
+    elif [ "$slot" = "primary" ] && [ -z "$(read_key global)" ]; then
+        # Primary is the effective wallpaper when no Global wallpaper is set.
+        render=true
+    fi
+else
+    if [ "$slot" = "$current_workspace" ]; then
+        render=true
+    elif [ "$slot" = "primary" ] && [ -z "$(read_key "w-${current_workspace}")" ]; then
+        # Primary is the effective wallpaper when the active workspace is unset.
+        render=true
     fi
 fi
 
-sed -i "s|^w-${workspace_id}=.*|w-${workspace_id}=${wallpaper}|" "$current_config"
+# Skip re-rendering if the value didn't actually change.
+if [ "$old_wallpaper" = "$wallpaper" ]; then
+    render=false
+fi
+
+[ "$render" = true ] && dispatch "$wallpaper"
+
+sed -i "s|^${key}=.*|${key}=${wallpaper}|" "$current_config"

--- a/.config/hypr/wallpaper-daemon/wallpaperengine-audio-devices.sh
+++ b/.config/hypr/wallpaper-daemon/wallpaperengine-audio-devices.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Lists audio OUTPUT devices for the reactive-wallpaper selector, one per line as
+#   <monitor source name><TAB><friendly description>
+# (Wallpaper Engine reacts to a sink's ".monitor" source.)
+
+pactl list sinks 2>/dev/null | awk -F': ' '
+    /^[[:space:]]*Name:/        { name = $2 }
+    /^[[:space:]]*Description:/ { if (name != "") { print name ".monitor" "\t" $2; name = "" } }
+'

--- a/.config/hypr/wallpaper-daemon/wallpaperengine-ctl.sh
+++ b/.config/hypr/wallpaper-daemon/wallpaperengine-ctl.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# wallpaperengine-ctl.sh <command...>
+#
+# Broadcasts a live control command to every running per-monitor engine so
+# option/property/speed changes apply instantly (no restart). Screen-scoped
+# commands (scaling/clamp/property) get the monitor inserted automatically;
+# everything else (speed/volume/mute/set ...) is passed through as-is.
+#
+# Exit status (so the caller can surface the failure or fall back to a restart):
+#   0  - at least one running engine accepted the command
+#   1  - no reachable engine, or every engine rejected it (e.g. an unsupported
+#        command, or an orphaned/unresponsive socket). The reason is printed.
+
+[ -n "$1" ] || exit 0
+
+found_socket=0
+delivered=0
+last_response=""
+
+for sock in "${XDG_RUNTIME_DIR:-/tmp}"/lwe-*.sock; do
+    [ -S "$sock" ] || continue
+    found_socket=1
+    monitor="${sock##*/lwe-}"
+    monitor="${monitor%.sock}"
+
+    case "$1" in
+        scaling|clamp|property) cmd="$1 $monitor ${*:2}" ;;
+        *)                      cmd="$*" ;;
+    esac
+
+    response="$(printf '%s\n' "$cmd" | timeout 2 socat - "UNIX-CONNECT:$sock" 2>/dev/null | tr -d '\r\n')"
+    last_response="$response"
+
+    case "$response" in
+        # No reply (dead/orphaned socket) or an explicit rejection -> not delivered here.
+        ""|error*|"unknown command"*) continue ;;
+    esac
+    delivered=$((delivered + 1))
+done
+
+if [ "$found_socket" = 0 ]; then
+    echo "no-socket"
+    exit 1
+fi
+if [ "$delivered" -eq 0 ]; then
+    echo "${last_response:-rejected}"
+    exit 1
+fi
+exit 0

--- a/.config/hypr/wallpaper-daemon/wallpaperengine-properties.sh
+++ b/.config/hypr/wallpaper-daemon/wallpaperengine-properties.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# wallpaperengine-properties.sh — manage per-wallpaper Wallpaper Engine
+# customizable properties (the "selectors": bool / slider / color / combo /
+# textinput) that get passed to linux-wallpaperengine via --set-property.
+#
+# Usage:
+#   wallpaperengine-properties.sh --list <id>            JSON of properties (with overrides applied)
+#   wallpaperengine-properties.sh --set  <id> <key> <v>  upsert an override
+#   wallpaperengine-properties.sh --reset <id>           clear all overrides
+#   wallpaperengine-properties.sh --current <monitor>    echo the active WE id (or nothing)
+#
+# Overrides are stored one "key=value" per line in
+#   ~/.config/hypr/wallpaper-daemon/config/properties/<id>.conf
+# which wallpaperengine.sh reads and turns into --set-property arguments.
+
+hyprDir="$HOME/.config/hypr"
+WORKSHOP_DIR="${WE_WORKSHOP_DIR:-$HOME/.local/share/Steam/steamapps/workshop/content/431960}"
+PROPS_DIR="$hyprDir/wallpaper-daemon/config/properties"
+
+cmd="$1"
+
+props_file() { echo "$PROPS_DIR/$1.conf"; }
+
+case "$cmd" in
+    --list)
+        id="$2"
+        proj="$WORKSHOP_DIR/$id/project.json"
+        [ -f "$proj" ] || { echo "[]"; exit 0; }
+
+        # Base properties from the wallpaper definition.
+        base="$(jq -c '
+            (.general.properties // {})
+            | to_entries
+            | map({
+                key: .key,
+                type: (.value.type // "unknown"),
+                text: (.value.text // .key),
+                value: (.value.value // null),
+                options: (.value.options // null),
+                min: (.value.min // null),
+                max: (.value.max // null),
+                step: (.value.step // null),
+                order: (.value.order // 0)
+              })
+            | sort_by(.order)
+        ' "$proj" 2>/dev/null)"
+        [ -z "$base" ] && base="[]"
+
+        # Build an overrides object from the saved conf.
+        ov="{}"
+        cfile="$(props_file "$id")"
+        if [ -f "$cfile" ]; then
+            while IFS='=' read -r k v; do
+                [ -z "$k" ] && continue
+                case "$k" in \#*) continue ;; esac
+                ov="$(jq -c --arg k "$k" --arg v "$v" '. + {($k): $v}' <<<"$ov")"
+            done < "$cfile"
+        fi
+
+        # Apply overrides over the base values.
+        printf '%s' "$base" | jq -c --argjson ov "$ov" \
+            'map(if ($ov[.key] != null) then (.value = $ov[.key]) else . end)'
+        ;;
+
+    --set)
+        id="$2"; key="$3"; value="$4"
+        [ -z "$id" ] || [ -z "$key" ] && { echo "Usage: --set <id> <key> <value>" >&2; exit 1; }
+        mkdir -p "$PROPS_DIR"
+        cfile="$(props_file "$id")"
+        touch "$cfile"
+        if grep -q "^${key}=" "$cfile"; then
+            sed -i "s|^${key}=.*|${key}=${value}|" "$cfile"
+        else
+            echo "${key}=${value}" >> "$cfile"
+        fi
+        ;;
+
+    --reset)
+        id="$2"
+        rm -f "$(props_file "$id")"
+        ;;
+
+    --current)
+        monitor="$2"
+        conf="$hyprDir/wallpaper-daemon/config/$monitor/defaults.conf"
+        [ -f "$conf" ] || exit 0
+        settings="$HOME/.config/ags/cache/settings/settings.json"
+        read_key() { grep "^$1=" "$conf" | cut -d'=' -f2- | head -n 1; }
+        mode="workspace"; src="workspace1"
+        if command -v jq >/dev/null 2>&1 && [ -f "$settings" ]; then
+            m="$(jq -r '(.wallpaper.mode.value) // "workspace"' "$settings" 2>/dev/null)"
+            [ -n "$m" ] && [ "$m" != "null" ] && mode="$m"
+            s="$(jq -r '(.wallpaper.primarySource.value) // "workspace1"' "$settings" 2>/dev/null)"
+            [ -n "$s" ] && [ "$s" != "null" ] && src="$s"
+        fi
+        ws="$(hyprctl monitors -j | jq -r --arg m "$monitor" '.[] | select(.name == $m) | .activeWorkspace.id')"
+        if [ "$mode" = "global" ]; then wp="$(read_key global)"; else wp="$(read_key "w-${ws}")"; fi
+        if [ -z "$wp" ]; then
+            [ "$src" = "custom" ] && wp="$(read_key primary)"
+            [ -z "$wp" ] && wp="$(read_key w-1)"
+        fi
+        case "$wp" in
+            */workshop/content/431960/*)
+                # <workshop>/<id>/preview.* -> id is the parent folder name
+                basename "$(dirname "$wp")"
+                ;;
+        esac
+        ;;
+
+    *)
+        echo "Usage: $0 --list <id> | --set <id> <key> <value> | --reset <id> | --current <monitor>" >&2
+        exit 1
+        ;;
+esac

--- a/.config/hypr/wallpaper-daemon/wallpaperengine-restart.sh
+++ b/.config/hypr/wallpaper-daemon/wallpaperengine-restart.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# wallpaperengine-restart.sh
+#
+# Restarts every running per-monitor engine and re-applies the current wallpaper.
+# Used for the few changes that can't be pushed live over the socket (e.g. the
+# audio capture device, which the recorder binds at startup).
+
+daemon="$HOME/.config/hypr/wallpaper-daemon"
+
+for monitor in $(hyprctl monitors -j | jq -r '.[].name'); do
+    sock="${XDG_RUNTIME_DIR:-/tmp}/lwe-$monitor.sock"
+    [ -S "$sock" ] || continue
+    pkill -f -- "--control-socket $sock" 2>/dev/null
+    rm -f "$sock"
+    "$daemon/apply-current.sh" "$monitor"
+done

--- a/.config/hypr/wallpaper-daemon/wallpaperengine.sh
+++ b/.config/hypr/wallpaper-daemon/wallpaperengine.sh
@@ -40,15 +40,16 @@ bin="$HOME/linux-wallpaperengine/build/output/linux-wallpaperengine"
 we()   { jq -r "($1) // empty" "$settings" 2>/dev/null; }
 send() { printf '%s\n' "$*" | socat - "UNIX-CONNECT:$sock" 2>/dev/null; }
 
-# Push this wallpaper's saved property overrides to the running engine. The control socket is
-# serviced once per render frame, so each round-trip costs up to a frame (seconds on a low-FPS
-# wallpaper). Fire them concurrently — the engine drains all pending clients in a single poll — so
-# N properties cost one frame instead of N.
-push_props() {
+# Stage this wallpaper's saved property overrides in the running engine BEFORE the swap: `stage`
+# only records the value (no live effect, no rebuild), so the following `bg` builds the wallpaper
+# once with every property already right — instead of building with defaults and then rebuilding
+# per structural property pushed afterwards. Fired concurrently (the engine drains all pending
+# clients in a single poll), so N properties cost one render frame, not N.
+stage_props() {
     local f="$daemon/config/properties/$id.conf"
     [ -f "$f" ] || return
     while IFS='=' read -r k v; do
-        [ -n "$k" ] && send "property $monitor $k $v" &
+        [ -n "$k" ] && send "stage $k $v" &
     done < "$f"
     wait
 }
@@ -97,25 +98,6 @@ theme_async() {
     disown
 }
 
-# Warm the engine's resident cache: build every distinct per-workspace *scene* now so later
-# workspace switches are instant binds instead of cold loads. Detached so it never delays startup;
-# each preload blocks one render frame in the engine, so we serialise (wait for "ok") to spread the
-# cost across frames instead of freezing rendering in one burst. Only scenes benefit (the engine
-# rebuilds video/web on demand), so non-scene items are skipped.
-preload_all() {
-    local conf="$daemon/config/$monitor/defaults.conf"
-    [ -f "$conf" ] || return
-    setsid bash -c '
-        sock="$1"; conf="$2"
-        grep -oE "/[^=]*workshop/content/431960/[0-9]+" "$conf" | sort -u | while IFS= read -r dir; do
-            t="$(jq -r ".type // empty" "$dir/project.json" 2>/dev/null | tr "[:upper:]" "[:lower:]")"
-            [ "$t" = scene ] || continue
-            printf "preload %s\n" "$dir" | socat - "UNIX-CONNECT:$sock" >/dev/null 2>&1
-        done
-    ' _ "$sock" "$conf" >/dev/null 2>&1 9>&- < /dev/null &
-    disown
-}
-
 # The engine renders every Wallpaper Engine type natively now — 2D scenes, web (CEF),
 # video, and 3D model (.mdl) scenes — so no special handling per type is needed here;
 # we just hand the item to the engine below. (The old three.js bake for 3D models is
@@ -126,9 +108,11 @@ preload_all() {
 # "error", a dead socket answers nothing. On "ok" swap; on "error" the engine is up but can't render
 # this item -> static fallback; on no answer the socket is stale -> fall through to a fresh start.
 if [ -S "$sock" ]; then
+    # Stage saved properties first (no-ops on a dead socket), then swap: the build happens once,
+    # with every property already right.
+    stage_props
     resp="$(send "bg $monitor $dir")"
     if [ "$resp" = ok ]; then
-        push_props
         # The swap is on screen now; drop the per-monitor lock before theming so back-to-back
         # workspace switches don't serialise behind colour regeneration.
         exec 9>&-
@@ -302,7 +286,6 @@ if [ "$started" = true ]; then
     # Do NOT re-push them over the socket here: that calls setProperty -> reloads
     # the wallpaper seconds after startup, which crashes CEF web wallpapers.
     theme_async
-    preload_all
 else
     fallback
 fi

--- a/.config/hypr/wallpaper-daemon/wallpaperengine.sh
+++ b/.config/hypr/wallpaper-daemon/wallpaperengine.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+#
+# wallpaperengine.sh <monitor> <preview>
+#
+# Applies a Steam Wallpaper Engine item. A persistent per-monitor engine process
+# is driven over a Unix control socket, so changing wallpaper is a live swap
+# (no restart). A new process is only started when one isn't already running for
+# the monitor. <preview> is the item's preview at <workshop>/<id>/preview.*.
+
+hyprdir="$HOME/.config/hypr"
+daemon="$hyprdir/wallpaper-daemon"
+settings="$HOME/.config/ags/cache/settings/settings.json"
+
+monitor="$1"
+preview="$2"
+[ -z "$monitor" ] || [ -z "$preview" ] && { echo "usage: wallpaperengine.sh <monitor> <preview>" >&2; exit 1; }
+
+dir="$(dirname "$preview")"          # workshop item folder = the wallpaper
+id="$(basename "$dir")"
+sock="${XDG_RUNTIME_DIR:-/tmp}/lwe-$monitor.sock"
+
+# Cache of real rendered frames (one PNG per item), produced by asking the live engine to
+# screenshot itself. Used as the theme-colour source (so the palette matches what's actually on
+# screen, not the workshop preview) and as a static fallback if the engine later can't run.
+preview_cache="${XDG_CACHE_HOME:-$HOME/.cache}/wallpaperengine/previews"
+
+# Serialize per monitor: two concurrent applies (e.g. a wallpaper switch racing the shell's
+# startup restore) would both pass the "no engine running" check and spawn two engines stacked
+# on the same output, fighting over the same control socket. With the lock the second caller
+# waits, then sees the live socket and does a live swap instead. Bounded wait so a stuck holder
+# can never freeze wallpaper switching outright. The engine launch below MUST close fd 9
+# (9>&-) or the long-lived engine inherits the lock and holds it for its whole lifetime.
+exec 9>"${XDG_RUNTIME_DIR:-/tmp}/lwe-$monitor.lock"
+flock -w 15 9 || { echo "wallpaperengine.sh: lock timeout for $monitor" >&2; exit 1; }
+
+bin="$HOME/linux-wallpaperengine/build/output/linux-wallpaperengine"
+[ -x "$bin" ] || bin="$(command -v linux-wallpaperengine)" || {
+    notify-send -u critical "Wallpaper Engine" "linux-wallpaperengine is not installed" 2>/dev/null; exit 1; }
+
+we()   { jq -r "($1) // empty" "$settings" 2>/dev/null; }
+send() { printf '%s\n' "$*" | socat - "UNIX-CONNECT:$sock" 2>/dev/null; }
+
+# Push this wallpaper's saved property overrides to the running engine.
+push_props() {
+    local f="$daemon/config/properties/$id.conf"
+    [ -f "$f" ] || return
+    while IFS='=' read -r k v; do
+        [ -n "$k" ] && send "property $monitor $k $v"
+    done < "$f"
+}
+
+# Engine can't render this item (web/3D-model/asset) or failed to start -> show a static image.
+# Prefer a previously cached rendered frame (looks like the actual wallpaper) over the workshop
+# preview. The 9>&- matters: these scripts spawn long-lived daemons (mpvpaper) that would otherwise
+# inherit the per-monitor lock fd and block every future wallpaper switch.
+fallback() {
+    notify-send "Wallpaper Engine" "'$id' can't be rendered — showing a static preview." 2>/dev/null
+    if [ -s "$preview_cache/$id.png" ]; then
+        "$daemon/hyprpaper.sh" "$monitor" "$preview_cache/$id.png" 9>&-
+        return
+    fi
+    case "${preview##*.}" in
+        gif|webm|mp4|GIF|WEBM|MP4) "$daemon/mpvpaper.sh" "$monitor" "$preview" 9>&- ;;
+        *)                         "$daemon/hyprpaper.sh" "$monitor" "$preview" 9>&- ;;
+    esac
+}
+
+# Ask the live engine to dump a rendered frame to the cache, wait for the async save, and echo the
+# path. Falls back (empty output) if the engine doesn't support it or doesn't produce the file.
+render_preview() {
+    mkdir -p "$preview_cache"
+    local out="$preview_cache/$id.png"
+    # Let a few new frames render first (after a live swap the engine rebuilds the scene), so the
+    # capture is the new wallpaper and not the previous one or a half-initialised frame.
+    sleep 0.5
+    [ "$(send "screenshot $out")" = ok ] || return 1
+    for _ in $(seq 1 40); do [ -s "$out" ] && { echo "$out"; return 0; }; sleep 0.1; done
+    return 1
+}
+
+# Generate the colour scheme from a real rendered frame when we can; otherwise the workshop preview.
+theme() {
+    local img; img="$(render_preview)"
+    [ -n "$img" ] || img="$preview"
+    "$hyprdir/theme/scripts/wal-theme.sh" "$img" >/dev/null 2>&1
+}
+
+# The engine renders every Wallpaper Engine type natively now — 2D scenes, web (CEF),
+# video, and 3D model (.mdl) scenes — so no special handling per type is needed here;
+# we just hand the item to the engine below. (The old three.js bake for 3D models is
+# gone.) fallback() is only for non-WE wallpapers (plain images/videos).
+
+# Already running for this monitor -> swap live.
+if [ -S "$sock" ] && [ "$(send ping)" = pong ]; then
+    [ "$(send "bg $monitor $dir")" = ok ] && { push_props; theme; exit 0; }
+    fallback
+    exit 0
+fi
+
+# Stop any existing engine for THIS monitor and WAIT for it to actually exit before the
+# socket file is removed below. A lingering engine keeps listening on the socket inode
+# after the file is unlinked, leaving an orphaned/unlinked socket — clients then get
+# "No such file or directory" and every live control command silently fails, which forces
+# full reloads instead of live changes. The trailing space anchors the match so "HDMI-A-1"
+# doesn't also match "HDMI-A-10".
+stop_engine_for_monitor () {
+    pgrep -f -- "--screen-root $monitor " >/dev/null 2>&1 || return 0
+    pkill -f -- "--screen-root $monitor " 2>/dev/null
+    for _ in $(seq 1 30); do
+        pgrep -f -- "--screen-root $monitor " >/dev/null 2>&1 || return 0
+        sleep 0.1
+    done
+    pkill -9 -f -- "--screen-root $monitor " 2>/dev/null
+    sleep 0.2
+}
+
+# Otherwise start a fresh engine for this monitor. Stop any stale wallpaper first.
+stop_engine_for_monitor
+rm -f "$sock"
+for pid in $(pgrep -x mpvpaper); do
+    tr '\0' ' ' < "/proc/$pid/cmdline" | grep -q -- "$monitor" && kill "$pid" 2>/dev/null
+done
+
+args=(--control-socket "$sock" --screen-root "$monitor" --bg "$dir")
+sc="$(we .wallpaperEngine.scaling.value)";  [ -n "$sc" ] && args+=(--scaling "$sc")
+cl="$(we .wallpaperEngine.clamping.value)"; [ -n "$cl" ] && args+=(--clamp "$cl")
+fp="$(we .wallpaperEngine.fps.value)";      [ -n "$fp" ] && args+=(--fps "$fp")
+rs="$(we .wallpaperEngine.renderScale.value)"; [ -n "$rs" ] && args+=(--render-scale "$rs")
+# Mute the wallpaper's own OUTPUT with volume 0, NOT --silent: --silent turns off
+# audio *capture* (audioprocessing) too, which kills sound-reactive wallpapers
+# (visualizers, reactive particles). Volume 0 silences output while reactivity
+# keeps working off the system audio.
+if [ "$(we .wallpaperEngine.mute.value)" = true ]; then
+    args+=(--volume 0)
+else
+    vo="$(we .wallpaperEngine.volume.value)"; [ -n "$vo" ] && args+=(--volume "$vo")
+fi
+[ "$(we .wallpaperEngine.noAutomute.value)" = true ]        && args+=(--noautomute)
+[ "$(we .wallpaperEngine.disableMouse.value)" = true ]      && args+=(--disable-mouse)
+[ "$(we .wallpaperEngine.disableParallax.value)" = true ]   && args+=(--disable-parallax)
+[ "$(we .wallpaperEngine.noFullscreenPause.value)" = true ] && args+=(--no-fullscreen-pause)
+sp="$(we .wallpaper.playbackSpeed.value)"; [ -n "$sp" ] && [ "$sp" != 1 ] && args+=(--playback-speed "$sp")
+ad="$(we .wallpaperEngine.audioDevice.value)"; [ -n "$ad" ] && args+=(--audio-device "$ad")
+
+# Saved per-wallpaper property overrides: apply at launch via --set-property so
+# they take effect on the initial load (the socket push_props below also handles
+# live changes once running). This is what enables e.g. a web wallpaper's
+# visualizer / background that ship disabled by default.
+propconf="$daemon/config/properties/$id.conf"
+if [ -f "$propconf" ]; then
+    while IFS='=' read -r k v; do
+        [ -n "$k" ] && args+=(--set-property "$k=$v")
+    done < "$propconf"
+fi
+
+# Launch under a small supervisor that keeps the engine alive across crashes: an abnormal
+# exit (segfault in CEF teardown, driver hiccup, ...) relaunches it after a short pause, while
+# an intentional stop does not — stop_engine_for_monitor's pkill pattern matches the
+# supervisor's own command line too (it carries the same --screen-root args), so a deliberate
+# stop kills both. Clean exits and TERM/KILL are treated as intentional.
+launch_supervised() {
+    setsid bash -c '
+        enginebin="$1"; shift
+        crashes=0
+        while :; do
+            "$enginebin" "$@" >/dev/null 2>&1
+            rc=$?
+            case "$rc" in 0|129|130|137|143) exit 0 ;; esac
+            crashes=$((crashes+1))
+            if [ "$crashes" -ge 5 ]; then
+                notify-send -u critical "Wallpaper Engine" "Engine keeps crashing (exit $rc) — giving up after 5 restarts." 2>/dev/null
+                exit 1
+            fi
+            notify-send "Wallpaper Engine" "Engine crashed (exit $rc) — restarting…" 2>/dev/null
+            sleep 2
+        done
+    ' _ "$bin" "${args[@]}" >/dev/null 2>&1 9>&- < /dev/null &
+    disown
+}
+
+# Confirm it stays up. CEF's GPU/offscreen init occasionally crashes on the first
+# try (Wayland), so retry a couple times before giving up — a far better outcome
+# than dropping a renderable wallpaper to a static preview.
+started=false
+for attempt in 1 2 3; do
+    stop_engine_for_monitor
+    rm -f "$sock"
+    launch_supervised
+    for _ in $(seq 1 25); do [ -S "$sock" ] && break; sleep 0.2; done
+    sleep 1
+    if pgrep -f -- "--control-socket $sock" >/dev/null 2>&1; then
+        started=true
+        break
+    fi
+done
+
+if [ "$started" = true ]; then
+    # Property overrides were already applied at launch via --set-property above.
+    # Do NOT re-push them over the socket here: that calls setProperty -> reloads
+    # the wallpaper seconds after startup, which crashes CEF web wallpapers.
+    theme
+else
+    fallback
+fi

--- a/.config/hypr/wallpaper-daemon/wallpaperengine.sh
+++ b/.config/hypr/wallpaper-daemon/wallpaperengine.sh
@@ -158,20 +158,64 @@ fi
 # an intentional stop does not — stop_engine_for_monitor's pkill pattern matches the
 # supervisor's own command line too (it carries the same --screen-root args), so a deliberate
 # stop kills both. Clean exits and TERM/KILL are treated as intentional.
+#
+# A watchdog also covers a nastier failure: the compositor can close the engine's layer surface
+# (output disable, `hyprctl reload`, monitor hotplug) after which the engine keeps running but
+# renders nothing — an invisible wallpaper that no exit-code check can catch. So the engine runs
+# in the background and we poll Hyprland: if the monitor is present but the engine has no layer on
+# it for a few checks, kill the engine so the loop relaunches it.
 launch_supervised() {
     local log="${XDG_CACHE_HOME:-$HOME/.cache}/lwe-$monitor.log"
     mkdir -p "$(dirname "$log")"
     setsid bash -c '
         enginebin="$1"; shift
         log="$1"; shift
+        monitor="$1"; shift
         crashes=0
+
+        # True if the engine has a live layer on $monitor. Also true (do not restart) when the
+        # monitor itself is gone or hyprctl/jq are unavailable — there is nothing to render on, so
+        # the watchdog must never thrash against a missing output or a probe it cannot run.
+        engine_layer_ok() {
+            command -v hyprctl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1 || return 0
+            local mons layers
+            mons="$(hyprctl monitors -j 2>/dev/null)" || return 0
+            printf "%s" "$mons" | jq -e --arg m "$monitor" "any(.[]; .name==\$m)" >/dev/null 2>&1 || return 0
+            layers="$(hyprctl layers -j 2>/dev/null)" || return 0
+            printf "%s" "$layers" | jq -e --arg m "$monitor" \
+                "(.[\$m].levels // {}) | any(.[][]?; .namespace|test(\"wallpaperengine\"))" >/dev/null 2>&1
+        }
+
         while :; do
             # Rotate the log so it never grows unbounded.
             [ -f "$log" ] && [ "$(stat -c%s "$log" 2>/dev/null || echo 0)" -gt 1000000 ] && : > "$log"
             start=$(date +%s)
-            "$enginebin" "$@" >>"$log" 2>&1
-            rc=$?
-            case "$rc" in 0|129|130|137|143) exit 0 ;; esac
+            "$enginebin" "$@" >>"$log" 2>&1 &
+            epid=$!
+
+            misses=0
+            while kill -0 "$epid" 2>/dev/null; do
+                sleep 15
+                kill -0 "$epid" 2>/dev/null || break
+                if engine_layer_ok; then
+                    misses=0
+                else
+                    misses=$((misses+1))
+                    if [ "$misses" -ge 3 ]; then
+                        printf "%s engine alive but no layer on %s — restarting\n" "$(date -Is)" "$monitor" >>"$log"
+                        kill "$epid" 2>/dev/null; sleep 2; kill -9 "$epid" 2>/dev/null
+                        break
+                    fi
+                fi
+            done
+            wait "$epid"; rc=$?
+
+            # A watchdog kill is an intentional restart, not an engine exit — skip the clean-stop
+            # check in that case so the loop always relaunches.
+            if [ "$misses" -lt 3 ]; then
+                case "$rc" in 0|129|130|137|143) exit 0 ;; esac
+            fi
+
             ran=$(( $(date +%s) - start ))
             # A run that survived a while then died (e.g. an EGL/DPMS surface loss when the monitor
             # slept) is NOT a startup crash-loop. Reset the counter on healthy uptime so occasional
@@ -189,7 +233,7 @@ launch_supervised() {
             notify-send "Wallpaper Engine" "Engine crashed (exit $rc) — restarting…" 2>/dev/null
             sleep 2
         done
-    ' _ "$bin" "$log" "${args[@]}" >/dev/null 2>&1 9>&- < /dev/null &
+    ' _ "$bin" "$log" "$monitor" "${args[@]}" >/dev/null 2>&1 9>&- < /dev/null &
     disown
 }
 

--- a/.config/hypr/wallpaper-daemon/wallpaperengine.sh
+++ b/.config/hypr/wallpaper-daemon/wallpaperengine.sh
@@ -159,22 +159,37 @@ fi
 # supervisor's own command line too (it carries the same --screen-root args), so a deliberate
 # stop kills both. Clean exits and TERM/KILL are treated as intentional.
 launch_supervised() {
+    local log="${XDG_CACHE_HOME:-$HOME/.cache}/lwe-$monitor.log"
+    mkdir -p "$(dirname "$log")"
     setsid bash -c '
         enginebin="$1"; shift
+        log="$1"; shift
         crashes=0
         while :; do
-            "$enginebin" "$@" >/dev/null 2>&1
+            # Rotate the log so it never grows unbounded.
+            [ -f "$log" ] && [ "$(stat -c%s "$log" 2>/dev/null || echo 0)" -gt 1000000 ] && : > "$log"
+            start=$(date +%s)
+            "$enginebin" "$@" >>"$log" 2>&1
             rc=$?
             case "$rc" in 0|129|130|137|143) exit 0 ;; esac
-            crashes=$((crashes+1))
+            ran=$(( $(date +%s) - start ))
+            # A run that survived a while then died (e.g. an EGL/DPMS surface loss when the monitor
+            # slept) is NOT a startup crash-loop. Reset the counter on healthy uptime so occasional
+            # crashes never accumulate to a permanent give-up.
+            if [ "$ran" -ge 60 ]; then crashes=0; else crashes=$((crashes+1)); fi
+            printf "%s engine exit %s after %ss (crashes=%s)\n" "$(date -Is)" "$rc" "$ran" "$crashes" >>"$log"
             if [ "$crashes" -ge 5 ]; then
-                notify-send -u critical "Wallpaper Engine" "Engine keeps crashing (exit $rc) — giving up after 5 restarts." 2>/dev/null
-                exit 1
+                # Rapid crash-loop: back off, then keep trying (do NOT give up permanently, so the
+                # wallpaper recovers when the monitor wakes / the transient condition clears).
+                notify-send -u critical "Wallpaper Engine" "Engine crash-looping (exit $rc) — backing off. Log: $log" 2>/dev/null
+                sleep 30
+                crashes=0
+                continue
             fi
             notify-send "Wallpaper Engine" "Engine crashed (exit $rc) — restarting…" 2>/dev/null
             sleep 2
         done
-    ' _ "$bin" "${args[@]}" >/dev/null 2>&1 9>&- < /dev/null &
+    ' _ "$bin" "$log" "${args[@]}" >/dev/null 2>&1 9>&- < /dev/null &
     disown
 }
 

--- a/.config/hypr/wallpaper-daemon/wallpaperengine.sh
+++ b/.config/hypr/wallpaper-daemon/wallpaperengine.sh
@@ -40,13 +40,17 @@ bin="$HOME/linux-wallpaperengine/build/output/linux-wallpaperengine"
 we()   { jq -r "($1) // empty" "$settings" 2>/dev/null; }
 send() { printf '%s\n' "$*" | socat - "UNIX-CONNECT:$sock" 2>/dev/null; }
 
-# Push this wallpaper's saved property overrides to the running engine.
+# Push this wallpaper's saved property overrides to the running engine. The control socket is
+# serviced once per render frame, so each round-trip costs up to a frame (seconds on a low-FPS
+# wallpaper). Fire them concurrently — the engine drains all pending clients in a single poll — so
+# N properties cost one frame instead of N.
 push_props() {
     local f="$daemon/config/properties/$id.conf"
     [ -f "$f" ] || return
     while IFS='=' read -r k v; do
-        [ -n "$k" ] && send "property $monitor $k $v"
+        [ -n "$k" ] && send "property $monitor $k $v" &
     done < "$f"
+    wait
 }
 
 # Engine can't render this item (web/3D-model/asset) or failed to start -> show a static image.
@@ -65,24 +69,32 @@ fallback() {
     esac
 }
 
-# Ask the live engine to dump a rendered frame to the cache, wait for the async save, and echo the
-# path. Falls back (empty output) if the engine doesn't support it or doesn't produce the file.
-render_preview() {
-    mkdir -p "$preview_cache"
-    local out="$preview_cache/$id.png"
-    # Let a few new frames render first (after a live swap the engine rebuilds the scene), so the
-    # capture is the new wallpaper and not the previous one or a half-initialised frame.
-    sleep 0.5
-    [ "$(send "screenshot $out")" = ok ] || return 1
-    for _ in $(seq 1 40); do [ -s "$out" ] && { echo "$out"; return 0; }; sleep 0.1; done
-    return 1
-}
-
-# Generate the colour scheme from a real rendered frame when we can; otherwise the workshop preview.
-theme() {
-    local img; img="$(render_preview)"
-    [ -n "$img" ] || img="$preview"
-    "$hyprdir/theme/scripts/wal-theme.sh" "$img" >/dev/null 2>&1
+# Regenerate the desktop colour scheme from the wallpaper — always in a detached, debounced
+# background job so it never delays the visible swap or holds the per-monitor lock (otherwise
+# back-to-back workspace switches queue behind each other's colour regen). The palette comes from a
+# real rendered frame: a cached frame is reused instantly, and only the first view of a wallpaper
+# pays for a screenshot. During rapid switching only the final wallpaper themes (marker guards it).
+theme_async() {
+    local marker="${XDG_RUNTIME_DIR:-/tmp}/lwe-theme-$monitor.target"
+    printf '%s' "$id" > "$marker"
+    setsid bash -c '
+        marker=$1; want=$2; sock=$3; preview=$4; cache=$5; wal=$6
+        # Settle briefly so a burst of workspace switches collapses to just the last one.
+        sleep 0.4
+        [ "$(cat "$marker" 2>/dev/null)" = "$want" ] || exit 0
+        out="$cache/$want.png"
+        if [ ! -s "$out" ]; then
+            mkdir -p "$cache"
+            printf "screenshot %s\n" "$out" | socat - "UNIX-CONNECT:$sock" >/dev/null 2>&1
+            for _ in $(seq 1 40); do [ -s "$out" ] && break; sleep 0.1; done
+        fi
+        # Only recolour if this is still the wallpaper on screen.
+        [ "$(cat "$marker" 2>/dev/null)" = "$want" ] || exit 0
+        [ -s "$out" ] || out="$preview"
+        "$wal" "$out" >/dev/null 2>&1
+    ' _ "$marker" "$id" "$sock" "$preview" "$preview_cache" "$hyprdir/theme/scripts/wal-theme.sh" \
+        >/dev/null 2>&1 9>&- < /dev/null &
+    disown
 }
 
 # The engine renders every Wallpaper Engine type natively now — 2D scenes, web (CEF),
@@ -90,11 +102,24 @@ theme() {
 # we just hand the item to the engine below. (The old three.js bake for 3D models is
 # gone.) fallback() is only for non-WE wallpapers (plain images/videos).
 
-# Already running for this monitor -> swap live.
-if [ -S "$sock" ] && [ "$(send ping)" = pong ]; then
-    [ "$(send "bg $monitor $dir")" = ok ] && { push_props; theme; exit 0; }
-    fallback
-    exit 0
+# Already running for this monitor -> swap live. The swap doubles as the liveness probe (saves a
+# round-trip, and each round-trip can cost up to a render frame): a live engine answers "ok" or
+# "error", a dead socket answers nothing. On "ok" swap; on "error" the engine is up but can't render
+# this item -> static fallback; on no answer the socket is stale -> fall through to a fresh start.
+if [ -S "$sock" ]; then
+    resp="$(send "bg $monitor $dir")"
+    if [ "$resp" = ok ]; then
+        push_props
+        # The swap is on screen now; drop the per-monitor lock before theming so back-to-back
+        # workspace switches don't serialise behind colour regeneration.
+        exec 9>&-
+        theme_async
+        exit 0
+    elif [ "$resp" = error ]; then
+        fallback
+        exit 0
+    fi
+    # empty/other response -> engine gone -> fall through to the fresh-start path below
 fi
 
 # Stop any existing engine for THIS monitor and WAIT for it to actually exit before the
@@ -257,7 +282,7 @@ if [ "$started" = true ]; then
     # Property overrides were already applied at launch via --set-property above.
     # Do NOT re-push them over the socket here: that calls setProperty -> reloads
     # the wallpaper seconds after startup, which crashes CEF web wallpapers.
-    theme
+    theme_async
 else
     fallback
 fi

--- a/.config/hypr/wallpaper-daemon/wallpaperengine.sh
+++ b/.config/hypr/wallpaper-daemon/wallpaperengine.sh
@@ -97,6 +97,25 @@ theme_async() {
     disown
 }
 
+# Warm the engine's resident cache: build every distinct per-workspace *scene* now so later
+# workspace switches are instant binds instead of cold loads. Detached so it never delays startup;
+# each preload blocks one render frame in the engine, so we serialise (wait for "ok") to spread the
+# cost across frames instead of freezing rendering in one burst. Only scenes benefit (the engine
+# rebuilds video/web on demand), so non-scene items are skipped.
+preload_all() {
+    local conf="$daemon/config/$monitor/defaults.conf"
+    [ -f "$conf" ] || return
+    setsid bash -c '
+        sock="$1"; conf="$2"
+        grep -oE "/[^=]*workshop/content/431960/[0-9]+" "$conf" | sort -u | while IFS= read -r dir; do
+            t="$(jq -r ".type // empty" "$dir/project.json" 2>/dev/null | tr "[:upper:]" "[:lower:]")"
+            [ "$t" = scene ] || continue
+            printf "preload %s\n" "$dir" | socat - "UNIX-CONNECT:$sock" >/dev/null 2>&1
+        done
+    ' _ "$sock" "$conf" >/dev/null 2>&1 9>&- < /dev/null &
+    disown
+}
+
 # The engine renders every Wallpaper Engine type natively now — 2D scenes, web (CEF),
 # video, and 3D model (.mdl) scenes — so no special handling per type is needed here;
 # we just hand the item to the engine below. (The old three.js bake for 3D models is
@@ -283,6 +302,7 @@ if [ "$started" = true ]; then
     # Do NOT re-push them over the socket here: that calls setProperty -> reloads
     # the wallpaper seconds after startup, which crashes CEF web wallpapers.
     theme_async
+    preload_all
 else
     fallback
 fi


### PR DESCRIPTION
## Summary
Adds Steam Wallpaper Engine support to ArchEclipse on Hyprland/Wayland: render scene/web/video/3D
Wallpaper Engine wallpapers via linux-wallpaperengine, driven by a per-monitor control-socket daemon
(live switching, no restart), with an AGS selector + per-wallpaper settings UI and an opt-in
installer step that builds the engine.

## ⚠️ Engine source — my fork, for now
The installer builds **`beingsuz/linux-wallpaperengine` @ `feat/better-wallpaper-support`** — a fork
carrying the Linux/Wayland feature work (web/CEF, native 3D `.mdl`, video, audio-reactive,
SceneScript) that upstream `linux-wallpaperengine` doesn't have yet. **This is temporary:** the
engine step is opt-in and the source is env/menu-overridable, and the intent is to upstream those
engine changes and re-point at upstream once they land.

## What's added
- **Daemon** (`.config/hypr/wallpaper-daemon/`): control-socket driver (live bg swap / properties /
  scaling / clamp / volume / audio-device / screenshot), crash supervision, race-free per-monitor
  launches, one shared renderer dispatcher (`dispatch.sh`), theme colour + static fallback from a
  real rendered frame, hyprpaper/mpvpaper fallbacks for non-WE wallpapers.
- **AGS**: WE section in the wallpaper switcher (lists *subscribed* items via Steam's subscription
  manifest, so unsubscribing drops them), per-wallpaper properties panel, WE + audio-device controls
  in settings, self-healing shell watchdog.
- **Installer**: opt-in `wallpaper_engine` step (`components/wallpaperengine.py`) that builds the
  engine; source selectable (fork / custom URL / skip).

## Notes
- Workshop wallpapers + WE `assets` require owning Wallpaper Engine on Steam.
- Non-WE wallpapers are unaffected (hyprpaper/mpvpaper fallbacks kept).


## Verification
Ran on Hyprland/Wayland: live wallpaper switching, per-wallpaper properties, audio-reactive
visualizers, theme palette derived from the rendered frame, and unsubscribe-removal.
