### PR TITLE
fix: isolate widget state per monitor

### DIFF
--- a/.config/ags/widgets/leftPanel/components/ChatBot.tsx
+++ b/.config/ags/widgets/leftPanel/components/ChatBot.tsx
@@ -52,69 +52,81 @@ const MESSAGE_FILE_PATH = `${GLib.get_home_dir()}/.config/ags/cache/chatbot`;
 // STATE MANAGEMENT
 // =============================================================================
 
-/**
- * Array of messages in the current active chat session
- * Each message contains content, role (user/assistant), timestamp, and optional metadata
- */
-const [messages, setMessages] = createState<Message[]>([]);
+// NOTE: Everything below (state, the chatBotEntry widget reference, helper
+// functions, and components) is created PER INSTANCE inside
+// createChatBotInstance(). ChatBot is mounted once per monitor (via
+// leftPanelWidgetSelectors -> LeftPanel.tsx, one Panel() per monitor), so
+// module-level createState()/let bindings here would be shared across
+// monitors -- the same root cause that broke BooruViewer's page navigation
+// across monitors. Each monitor now keeps its own independent messages,
+// sessions, active session, and input widget reference, fully isolated from
+// any other monitor's ChatBot.
+const createChatBotInstance = () => {
+  /**
+   * Array of messages in the current active chat session
+   * Each message contains content, role (user/assistant), timestamp, and optional metadata
+   */
+  const [messages, setMessages] = createState<Message[]>([]);
 
-/**
- * Array of all available sessions for the current API model
- * Sessions persist across app restarts and are loaded from the filesystem
- */
-const [sessions, setSessions] = createState<Session[]>([]);
+  /**
+   * Array of all available sessions for the current API model
+   * Sessions persist across app restarts and are loaded from the filesystem
+   */
+  const [sessions, setSessions] = createState<Session[]>([]);
 
-/**
- * ID of the currently active session being displayed
- * Defaults to "default" session which is automatically created
- */
-const [activeSessionId, setActiveSessionId] = createState<string>("default");
+  /**
+   * ID of the currently active session being displayed
+   * Defaults to "default" session which is automatically created
+   */
+  const [activeSessionId, setActiveSessionId] = createState<string>(
+    "default",
+  );
 
-/**
- * Current API model/provider value (e.g., "openrouter/gpt-4")
- * Used to determine which API to call and where to store messages
- */
-const [currentApiModel, setCurrentApiModel] = createState<string>("");
+  /**
+   * Current API model/provider value (e.g., "openrouter/gpt-4")
+   * Used to determine which API to call and where to store messages
+   */
+  const [currentApiModel, setCurrentApiModel] = createState<string>("");
 
-/**
- * Status indicator for API requests and operations
- * - "idle": No operation in progress
- * - "loading": Request in progress
- * - "success": Request completed successfully
- * - "error": Request failed
- */
-const [progressStatus, setProgressStatus] = createState<
-  "loading" | "error" | "success" | "idle"
->("idle");
+  /**
+   * Status indicator for API requests and operations
+   * - "idle": No operation in progress
+   * - "loading": Request in progress
+   * - "success": Request completed successfully
+   * - "error": Request failed
+   */
+  const [progressStatus, setProgressStatus] = createState<
+    "loading" | "error" | "success" | "idle"
+  >("idle");
 
-/**
- * Toggle state for image generation feature
- * When enabled, AI responses may include generated images
- * Only available for API models that support image generation
- */
-const [chatBotImageGeneration, setChatBotImageGeneration] =
-  createState<boolean>(false);
+  /**
+   * Toggle state for image generation feature
+   * When enabled, AI responses may include generated images
+   * Only available for API models that support image generation
+   */
+  const [chatBotImageGeneration, setChatBotImageGeneration] =
+    createState<boolean>(false);
 
-/**
- * Reference to the message input entry widget for programmatic focus control
- * Allows auto-focusing the input field when the chatbot panel is activated
- */
-let chatBotEntry: Gtk.Widget | null = null;
+  /**
+   * Reference to the message input entry widget for programmatic focus control
+   * Allows auto-focusing the input field when the chatbot panel is activated
+   */
+  let chatBotEntry: Gtk.Widget | null = null;
 
-// =============================================================================
-// UTILITY FUNCTIONS - FILE SYSTEM & PATH MANAGEMENT
-// =============================================================================
+  // =============================================================================
+  // UTILITY FUNCTIONS - FILE SYSTEM & PATH MANAGEMENT
+  // =============================================================================
 
-/**
- * Constructs the file path for storing chat history of a specific session
- * @param {string} apiModel - The API model identifier (e.g., "openrouter/gpt-4")
- * @param {string} sessionId - The unique session identifier
- * @returns {string} Full path to the history.json file for the session
- * @example getMessageFilePath("openrouter/gpt-4", "default")
- *          => "./cache/chatbot/openrouter/gpt-4/sessions/default/history.json"
- */
-const getMessageFilePath = (apiModel: string, sessionId: string): string =>
-  `${MESSAGE_FILE_PATH}/${apiModel}/sessions/${sessionId}/history.json`;
+  /**
+   * Constructs the file path for storing chat history of a specific session
+   * @param {string} apiModel - The API model identifier (e.g., "openrouter/gpt-4")
+   * @param {string} sessionId - The unique session identifier
+   * @returns {string} Full path to the history.json file for the session
+   * @example getMessageFilePath("openrouter/gpt-4", "default")
+   *          => "./cache/chatbot/openrouter/gpt-4/sessions/default/history.json"
+   */
+  const getMessageFilePath = (apiModel: string, sessionId: string): string =>
+    `${MESSAGE_FILE_PATH}/${apiModel}/sessions/${sessionId}/history.json`;
 
 /**
  * Constructs the directory path where all sessions for an API model are stored
@@ -1427,53 +1439,69 @@ const BottomBar = (): JSX.Element => (
  * - Could add memoization for formatText() to improve performance
  * - Consider debouncing auto-scroll for better performance with rapid messages
  */
+  // This is the JSX returned for THIS instance. Everything above this point
+  // inside createChatBotInstance() (messages, sessions, activeSessionId,
+  // chatBotEntry, sendMessage, Messages, SessionTabs, ApiList, etc.) is now a
+  // fresh closure created per call -- i.e. per monitor -- instead of shared
+  // module state.
+  return (): JSX.Element => {
+    return (
+      <box
+        class="chat-bot"
+        orientation={Gtk.Orientation.VERTICAL}
+        hexpand
+        spacing={10}
+        $={async (self) => {
+          // Setup auto-focus on mouse enter
+          const motion = new Gtk.EventControllerMotion();
+          motion.connect("enter", () => {
+            if (chatBotEntry) {
+              chatBotEntry.grab_focus();
+            }
+          });
+          self.add_controller(motion);
+
+          // Initialize chatbot state on component mount
+          const initialApiModel = globalSettings.peek().chatBot.api.value;
+          setCurrentApiModel(initialApiModel);
+
+          // Load sessions and activate the first one
+          const initialSessionId = await loadSessions(initialApiModel);
+          setActiveSessionId(initialSessionId);
+
+          // Load messages for the initial session
+          fetchMessages(initialApiModel, initialSessionId);
+
+          // Subscribe to session changes to automatically reload messages
+          activeSessionId.subscribe(() => {
+            reloadCurrentMessages();
+          });
+        }}
+      >
+        {/* API information and setup guide */}
+        <Info />
+
+        {/* Scrollable message history */}
+        <Messages />
+
+        <BottomBar />
+
+        <Progress
+          status={progressStatus}
+          transitionType={Gtk.RevealerTransitionType.SWING_DOWN}
+          custom_class="booru-progress"
+        />
+      </box>
+    );
+  };
+};
+
+// Public entry point: called once per ChatBot mount (once per monitor, since
+// LeftPanel.tsx instantiates this widget separately for each monitor's
+// panel). Each call produces an independent state closure, so switching
+// sessions/messages on one monitor's panel can no longer affect or get
+// stolen by another monitor's panel.
 export default (): JSX.Element => {
-  return (
-    <box
-      class="chat-bot"
-      orientation={Gtk.Orientation.VERTICAL}
-      hexpand
-      spacing={10}
-      $={async (self) => {
-        // Setup auto-focus on mouse enter
-        const motion = new Gtk.EventControllerMotion();
-        motion.connect("enter", () => {
-          if (chatBotEntry) {
-            chatBotEntry.grab_focus();
-          }
-        });
-        self.add_controller(motion);
-
-        // Initialize chatbot state on component mount
-        const initialApiModel = globalSettings.peek().chatBot.api.value;
-        setCurrentApiModel(initialApiModel);
-
-        // Load sessions and activate the first one
-        const initialSessionId = await loadSessions(initialApiModel);
-        setActiveSessionId(initialSessionId);
-
-        // Load messages for the initial session
-        fetchMessages(initialApiModel, initialSessionId);
-
-        // Subscribe to session changes to automatically reload messages
-        activeSessionId.subscribe(() => {
-          reloadCurrentMessages();
-        });
-      }}
-    >
-      {/* API information and setup guide */}
-      <Info />
-
-      {/* Scrollable message history */}
-      <Messages />
-
-      <BottomBar />
-
-      <Progress
-        status={progressStatus}
-        transitionType={Gtk.RevealerTransitionType.SWING_DOWN}
-        custom_class="booru-progress"
-      />
-    </box>
-  );
+  const Instance = createChatBotInstance();
+  return Instance();
 };

--- a/.config/ags/widgets/leftPanel/components/MangaViewer.tsx
+++ b/.config/ags/widgets/leftPanel/components/MangaViewer.tsx
@@ -11,44 +11,55 @@ import { globalSettings, globalTransition } from "../../../variables";
 import GLib from "gi://GLib";
 import Gio from "gi://Gio";
 
-const [mangaList, setMangaList] = createState<Manga[]>([]);
-const [selectedManga, setSelectedManga] = createState<Manga | null>(null);
-const [chapters, setChapters] = createState<Chapter[]>([]);
-const [selectedChapter, setSelectedChapter] = createState<Chapter | null>(null);
-const [pages, setPages] = createState<Page[]>([]);
-const [pageCache, setPageCache] = createState<Record<number, Page>>({});
-const [currentPageIndex, setCurrentPageIndex] = createState(0);
-const [currentTab, setCurrentTab] = createState<string>("Manga");
-const [progressStatus, setProgressStatus] = createState<
-  "loading" | "error" | "success" | "idle"
->("idle");
-const [searchQuery, setSearchQuery] = createState<string>("");
-const [initialized, setInitialized] = createState(false);
-const [bottomIsRevealed, setBottomIsRevealed] = createState<boolean>(false);
-
-const [currentApi, setCurrentApi] = createState<string>("mangadex");
-
-const pageInfo = createComputed(() => {
-  const all = pages();
-  const idx = currentPageIndex();
-  return {
-    label: all.length > 0 ? `Page ${idx + 1} / ${all.length}` : "No pages",
-    canPrev: idx > 0,
-    canNext: all.length > 0 && idx < all.length - 1,
-  };
-});
-
-const displayedPage = createComputed(
-  () => pageCache()[currentPageIndex()] ?? null,
-);
-
-const panelWidth = createComputed(() => globalSettings().leftPanel.width);
-
 const scriptPath = `${GLib.get_home_dir()}/.config/ags/scripts/manga.py`;
 
-const getProviderFlag = () => `--provider ${currentApi.get()}`;
+// NOTE: Everything below (state, computed values, helpers, and components)
+// is created PER INSTANCE inside createMangaViewerInstance(). MangaViewer is
+// mounted once per monitor (via leftPanelWidgetSelectors -> LeftPanel.tsx,
+// one Panel() per monitor), so module-level createState()/createComputed()
+// here would be shared across monitors -- the same root cause that broke
+// BooruViewer's page navigation across monitors. Each monitor now keeps its
+// own independent manga list, selected manga/chapter, page cache, and tab
+// state, fully isolated from any other monitor's MangaViewer.
+const createMangaViewerInstance = () => {
+  const [mangaList, setMangaList] = createState<Manga[]>([]);
+  const [selectedManga, setSelectedManga] = createState<Manga | null>(null);
+  const [chapters, setChapters] = createState<Chapter[]>([]);
+  const [selectedChapter, setSelectedChapter] = createState<Chapter | null>(
+    null,
+  );
+  const [pages, setPages] = createState<Page[]>([]);
+  const [pageCache, setPageCache] = createState<Record<number, Page>>({});
+  const [currentPageIndex, setCurrentPageIndex] = createState(0);
+  const [currentTab, setCurrentTab] = createState<string>("Manga");
+  const [progressStatus, setProgressStatus] = createState<
+    "loading" | "error" | "success" | "idle"
+  >("idle");
+  const [searchQuery, setSearchQuery] = createState<string>("");
+  const [initialized, setInitialized] = createState(false);
+  const [bottomIsRevealed, setBottomIsRevealed] = createState<boolean>(false);
 
-const getSortedChaptersList = (chaptersList: Chapter[]) => {
+  const [currentApi, setCurrentApi] = createState<string>("mangadex");
+
+  const pageInfo = createComputed(() => {
+    const all = pages();
+    const idx = currentPageIndex();
+    return {
+      label: all.length > 0 ? `Page ${idx + 1} / ${all.length}` : "No pages",
+      canPrev: idx > 0,
+      canNext: all.length > 0 && idx < all.length - 1,
+    };
+  });
+
+  const displayedPage = createComputed(
+    () => pageCache()[currentPageIndex()] ?? null,
+  );
+
+  const panelWidth = createComputed(() => globalSettings().leftPanel.width);
+
+  const getProviderFlag = () => `--provider ${currentApi.get()}`;
+
+  const getSortedChaptersList = (chaptersList: Chapter[]) => {
   return [...chaptersList]
     .sort((a, b) => {
       // 1. Sorting by volumes
@@ -765,56 +776,72 @@ const Actions = () => {
   );
 };
 
-export default () => {
-  if (!initialized.get()) {
-    setInitialized(true);
-    fetchPopular();
-  }
-  return (
-    <box
-      orientation={Gtk.Orientation.VERTICAL}
-      class="manga-viewer"
-      spacing={10}
-      $={(self) => {
-        const keyController = new Gtk.EventControllerKey();
-        keyController.connect("key-pressed", (_, keyval: number) => {
-          if (currentTab.get() === "Pages") {
-            if (keyval === Gdk.KEY_Left) {
-              goToPage("prev");
-              return true;
-            }
-            if (keyval === Gdk.KEY_Right) {
-              goToPage("next");
-              return true;
-            }
-          }
-          if (keyval === Gdk.KEY_Up && !bottomIsRevealed.get()) {
-            setBottomIsRevealed(true);
-            return true;
-          }
-          if (keyval === Gdk.KEY_Down && bottomIsRevealed.get()) {
-            setBottomIsRevealed(false);
-            return true;
-          }
-          return false;
-        });
-        self.add_controller(keyController);
-      }}
-    >
-      <Content />
+  // This is the JSX returned for THIS instance. Everything above this point
+  // inside createMangaViewerInstance() (mangaList, selectedManga, pages,
+  // pageCache, currentTab, fetchPopular, goToPage, Content, Actions, etc.)
+  // is now a fresh closure created per call -- i.e. per monitor -- instead
+  // of shared module state.
+  return () => {
+    if (!initialized.get()) {
+      setInitialized(true);
+      fetchPopular();
+    }
+    return (
       <box
-        class={"bottom-bar"}
         orientation={Gtk.Orientation.VERTICAL}
+        class="manga-viewer"
         spacing={10}
+        $={(self) => {
+          const keyController = new Gtk.EventControllerKey();
+          keyController.connect("key-pressed", (_, keyval: number) => {
+            if (currentTab.get() === "Pages") {
+              if (keyval === Gdk.KEY_Left) {
+                goToPage("prev");
+                return true;
+              }
+              if (keyval === Gdk.KEY_Right) {
+                goToPage("next");
+                return true;
+              }
+            }
+            if (keyval === Gdk.KEY_Up && !bottomIsRevealed.get()) {
+              setBottomIsRevealed(true);
+              return true;
+            }
+            if (keyval === Gdk.KEY_Down && bottomIsRevealed.get()) {
+              setBottomIsRevealed(false);
+              return true;
+            }
+            return false;
+          });
+          self.add_controller(keyController);
+        }}
       >
-        <Actions />
-        <PageNavigation />
-        <ChapterNavigation />
-        <UrlBar />
-        <Sections />
-        <Tabs />
+        <Content />
+        <box
+          class={"bottom-bar"}
+          orientation={Gtk.Orientation.VERTICAL}
+          spacing={10}
+        >
+          <Actions />
+          <PageNavigation />
+          <ChapterNavigation />
+          <UrlBar />
+          <Sections />
+          <Tabs />
+        </box>
+        <Progress status={progressStatus} />
       </box>
-      <Progress status={progressStatus} />
-    </box>
-  );
+    );
+  };
+};
+
+// Public entry point: called once per MangaViewer mount (once per monitor,
+// since LeftPanel.tsx instantiates this widget separately for each
+// monitor's panel). Each call produces an independent state closure, so
+// browsing manga/chapters/pages on one monitor's panel can no longer affect
+// or get stolen by another monitor's panel.
+export default () => {
+  const Instance = createMangaViewerInstance();
+  return Instance();
 };

--- a/.config/ags/widgets/rightPanel/components/CryptoViewer.tsx
+++ b/.config/ags/widgets/rightPanel/components/CryptoViewer.tsx
@@ -24,13 +24,23 @@ interface CryptoEntry {
 // Available timeframes
 const timeframes = ["1h", "24h", "7d", "30d", "90d", "1y"];
 
-// Variables
-const [cryptoEntries, setCryptoEntries] = createState<CryptoEntry[]>([]);
-const [showAddForm, setShowAddForm] = createState(false);
-const [editingEntry, setEditingEntry] = createState<CryptoEntry | null>(null);
+// NOTE: Everything below (state + components) is created PER INSTANCE inside
+// createCryptoWidgetInstance(). CryptoWidget is mounted once per monitor (via
+// rightPanelWidgetSelectors -> RightPanel.tsx, one Panel() per monitor), so
+// module-level createState() here would be shared across monitors -- the
+// same root cause that broke BooruViewer's page navigation across monitors.
+// Each monitor now keeps its own independent entry list, add-form state, and
+// editing state, fully isolated from any other monitor's CryptoWidget.
+const createCryptoWidgetInstance = () => {
+  // Variables
+  const [cryptoEntries, setCryptoEntries] = createState<CryptoEntry[]>([]);
+  const [showAddForm, setShowAddForm] = createState(false);
+  const [editingEntry, setEditingEntry] = createState<CryptoEntry | null>(
+    null,
+  );
 
-// Storage functions
-const saveEntriesToFile = async (entries: CryptoEntry[]) => {
+  // Storage functions
+  const saveEntriesToFile = async (entries: CryptoEntry[]) => {
   try {
     await execAsync(
       `mkdir -p  ${GLib.get_home_dir()}/.config/ags/cache/crypto`,
@@ -56,12 +66,7 @@ const loadEntriesFromFile = async (): Promise<CryptoEntry[]> => {
   }
 };
 
-// Initialize entries on load
-loadEntriesFromFile().then((entries) => {
-  setCryptoEntries(entries);
-});
-
-// Entry form component
+  // Entry form component
 const CryptoForm = ({
   entry,
   isEdit = false,
@@ -293,58 +298,78 @@ const CryptoEntryItem = ({ entry }: { entry: CryptoEntry }) => {
   );
 };
 
-// Main component
-const CryptoWidget = ({
+  // Main component for this instance
+  const CryptoWidget = ({
+    className,
+  }: {
+    className?: string | Accessor<string>;
+  }) => {
+    const toggleForm = () => {
+      setEditingEntry(null);
+      setShowAddForm(!showAddForm.get());
+    };
+
+    return (
+      <box
+        class={`crypto-widget ${className ?? ""}`}
+        orientation={Gtk.Orientation.VERTICAL}
+        spacing={5}
+        $={() => {
+          // Load this instance's entries once it mounts
+          loadEntriesFromFile().then((entries) => {
+            setCryptoEntries(entries);
+          });
+        }}
+      >
+        <box class="header">
+          <label
+            class="title"
+            label="Crypto Tracker"
+            hexpand
+            halign={Gtk.Align.START}
+          />
+          <button
+            class="add-btn"
+            label={showAddForm((show) => (show ? "✕" : "+"))}
+            onClicked={toggleForm}
+          />
+        </box>
+
+        <revealer
+          revealChild={showAddForm}
+          transitionType={Gtk.RevealerTransitionType.SWING_DOWN}
+          transitionDuration={globalTransition}
+        >
+          <With value={editingEntry}>
+            {(entry) =>
+              entry ? CryptoForm({ entry, isEdit: true }) : CryptoForm({})
+            }
+          </With>
+        </revealer>
+
+        <scrolledwindow class="crypto-list" vexpand>
+          <box orientation={Gtk.Orientation.VERTICAL} spacing={8}>
+            <For each={cryptoEntries}>
+              {(entry) => CryptoEntryItem({ entry })}
+            </For>
+          </box>
+        </scrolledwindow>
+      </box>
+    );
+  };
+
+  return CryptoWidget;
+};
+
+// Public entry point: called once per CryptoWidget mount (once per monitor).
+// Each call produces a fresh state closure via createCryptoWidgetInstance(),
+// so the returned component function captures its own independent
+// cryptoEntries/showAddForm/editingEntry rather than module-shared state.
+export default ({
   className,
 }: {
   className?: string | Accessor<string>;
 }) => {
-  const toggleForm = () => {
-    setEditingEntry(null);
-    setShowAddForm(!showAddForm.get());
-  };
-
-  return (
-    <box
-      class={`crypto-widget ${className ?? ""}`}
-      orientation={Gtk.Orientation.VERTICAL}
-      spacing={5}
-    >
-      <box class="header">
-        <label
-          class="title"
-          label="Crypto Tracker"
-          hexpand
-          halign={Gtk.Align.START}
-        />
-        <button
-          class="add-btn"
-          label={showAddForm((show) => (show ? "✕" : "+"))}
-          onClicked={toggleForm}
-        />
-      </box>
-
-      <revealer
-        revealChild={showAddForm}
-        transitionType={Gtk.RevealerTransitionType.SWING_DOWN}
-        transitionDuration={globalTransition}
-      >
-        <With value={editingEntry}>
-          {(entry) =>
-            entry ? CryptoForm({ entry, isEdit: true }) : CryptoForm({})
-          }
-        </With>
-      </revealer>
-
-      <scrolledwindow class="crypto-list" vexpand>
-        <box orientation={Gtk.Orientation.VERTICAL} spacing={8}>
-          <For each={cryptoEntries}>
-            {(entry) => CryptoEntryItem({ entry })}
-          </For>
-        </box>
-      </scrolledwindow>
-    </box>
-  );
+  const Instance = createCryptoWidgetInstance();
+  return Instance({ className });
 };
-
-export default CryptoWidget;

--- a/.config/ags/widgets/rightPanel/components/ScriptTimer.tsx
+++ b/.config/ags/widgets/rightPanel/components/ScriptTimer.tsx
@@ -30,13 +30,27 @@ const predefinedCommands = [
   { label: "⚡ Shutdown", command: "shutdown -h now" },
 ];
 
-// Variables
-const [scriptTasks, setScriptTasks] = createState<ScriptTask[]>([]);
-const [showAddForm, setShowAddForm] = createState(false);
-const [editingTask, setEditingTask] = createState<ScriptTask | null>(null);
+// NOTE: Everything below (state + components) is created PER INSTANCE inside
+// createScriptTimerInstance(). ScriptTimer is mounted once per monitor (via
+// rightPanelWidgetSelectors -> RightPanel.tsx, one Panel() per monitor), so
+// module-level createState() here would be shared across monitors -- the
+// same root cause that broke BooruViewer's page navigation across monitors.
+// Each monitor now keeps its own independent task list, add-form state, and
+// editing state, fully isolated from any other monitor's ScriptTimer.
+// NOTE: with full per-monitor isolation, if the same tasks.json is loaded by
+// two monitors, each monitor's own setInterval(checkTasks, ...) will run
+// independently against its own in-memory copy. If a one-time task fires
+// while both monitors have it loaded, both could attempt to execute it
+// around the same time; this mirrors running two independent ScriptTimer
+// instances in general and is an accepted tradeoff of full isolation.
+const createScriptTimerInstance = () => {
+  // Variables
+  const [scriptTasks, setScriptTasks] = createState<ScriptTask[]>([]);
+  const [showAddForm, setShowAddForm] = createState(false);
+  const [editingTask, setEditingTask] = createState<ScriptTask | null>(null);
 
-// Storage functions
-const saveTasksToFile = async (tasks: ScriptTask[]) => {
+  // Storage functions
+  const saveTasksToFile = async (tasks: ScriptTask[]) => {
   try {
     await execAsync(
       `mkdir -p  ${GLib.get_home_dir()}/.config/ags/cache/script-timer`,
@@ -432,4 +446,18 @@ const ScriptTimer = ({
   );
 };
 
-export default ScriptTimer;
+  return ScriptTimer;
+};
+
+// Public entry point: called once per ScriptTimer mount (once per monitor).
+// Each call produces a fresh state closure via createScriptTimerInstance(),
+// so the returned component function captures its own independent
+// scriptTasks/showAddForm/editingTask rather than module-shared state.
+export default ({
+  className,
+}: {
+  className?: string | Accessor<string>;
+}) => {
+  const Instance = createScriptTimerInstance();
+  return Instance({ className });
+};


### PR DESCRIPTION
Fixes widget state sharing across monitors by isolating state per instance.

Previously, module-level state in ChatBot, MangaViewer, CryptoViewer, and ScriptTimer was shared across all monitors, causing issues where actions on one monitor would affect others (e.g., switching chat sessions or manga pages).

Each widget now creates its own state closure per monitor via instance factory functions (createChatBotInstance, createMangaViewerInstance, etc.).