### PR TITLE
feat(maintenance): add python-pillow, update hyprpm call order

### DIFF
--- a/.config/hypr/maintenance/components/packages.py
+++ b/.config/hypr/maintenance/components/packages.py
@@ -40,6 +40,7 @@ PACKAGES: list[str] = [
     "translate-shell",
     "python2-bin",
     "python-requests",
+    "python-pillow",
     "zsh",
     "zsh-auto-notify",
     "zsh-history-substring-search",

--- a/.config/hypr/maintenance/components/plugins.py
+++ b/.config/hypr/maintenance/components/plugins.py
@@ -17,6 +17,8 @@ def install_plugins() -> None:
     run_shell("echo ' ArchEclipse ' | lolcat", check=False)
     run_shell("figlet 'PLUGINS' -f slant | lolcat", check=False)
 
+    run_cmd(["hyprpm", "update"])
+
     plugins = [
         ("hyprland-plugins", "https://github.com/hyprwm/hyprland-plugins"),
         ("dynamic-cursors", "https://github.com/virtcode/hypr-dynamic-cursors"),
@@ -31,7 +33,6 @@ def install_plugins() -> None:
         run_cmd(["hyprpm", "add", repo])
         run_cmd(["hyprpm", "enable", plugin])
 
-    run_cmd(["hyprpm", "update"])
     run_cmd(["hyprctl", "reload"], check=False)
 
 


### PR DESCRIPTION
Fix dependency issues for fresh system installations

**Problems addressed:**
- `~/.config/ags/scripts/manga.py` failed with `ModuleNotFoundError: No module named 'PIL'` due to missing `python-pillow` package
- `install.py` → `plugins.py` failed with `Headers outdated, please run hyprpm update` on new systems

**Changes:**
- Added `python-pillow` to `.config/hypr/maintenance/components/packages.py`
- Moved `hyprpm update` to the start of `install_plugins()` in `.config/hypr/maintenance/components/plugins.py`

**Fixes:**
Both issues are now resolved for clean system setups.