### PR TITLE
fix(bar): prevent volume slider oscillating between levels

### DIFF
--- a/.config/ags/widgets/bar/components/Utilities.tsx
+++ b/.config/ags/widgets/bar/components/Utilities.tsx
@@ -211,7 +211,11 @@ function Volume() {
       // step={0.1} // Gtk.Scale doesn't have step prop directly in JSX usually, handled by adjustment or set_increment
       class="slider"
       widthRequest={100}
-      onValueChanged={(self) => (speaker.volume = self.get_value())}
+      onValueChanged={(self) => {
+        // external volume changes (fn keys, pavucontrol) also fire this and loop back
+        if (Math.abs(self.get_value() - speaker.volume) < 0.001) return;
+        speaker.volume = self.get_value();
+      }}
       value={volume((v: number) => (isNaN(v) || v < 0 ? 0 : v > 1 ? 1 : v))}
     />
   );


### PR DESCRIPTION
Fix volume slider oscillating between levels when changed externally

**Problem addressed:**
- The bar volume slider glitches between two adjacent levels (e.g. 85% <-> 86%) when volume is changed via the fn keys or pavucontrol. The slider binds `value` to the speaker volume and also writes it back on every `value-changed`, so external changes echo back and re-quantize through WirePlumber in a loop.

**Changes:**
- In `.config/ags/widgets/bar/components/Utilities.tsx`, skip the writeback in `onValueChanged` when the slider value already matches `speaker.volume`, so only real user drags update the volume.

**Fixes:**
Volume no longer oscillates; fn keys and pavucontrol set it cleanly.