### PR TITLE
Fixed RAM percentage calculation logic error in Top Bar

### DIFF
--- a/.config/ags/widgets/bar/components/Utilities.tsx
+++ b/.config/ags/widgets/bar/components/Utilities.tsx
@@ -464,9 +464,9 @@ function ResourceMonitor() {
               icon=""
             />
             <CircularProgress
-              visible={res?.ramUsedGB !== undefined}
-              tooltipText={`RAM Usage ${res?.ramUsedGB}%`}
-              value={res?.ramUsedGB ? res?.ramUsedGB / 100 : 0}
+              visible={res?.ramUsedGB !== undefined && res?.ramTotalGB !== undefined}
+              tooltipText={`RAM Usage ${res?.ramUsedGB && res?.ramTotalGB ? Math.round((res.ramUsedGB>
+              value={res?.ramUsedGB && res?.ramTotalGB ? res.ramUsedGB / res.ramTotalGB : 0}
               className="ram-monitor"
               icon=""
             />


### PR DESCRIPTION
## Description
Fixed a critical math logic error where the raw RAM usage value (in GB) was being directly displayed as the percentage value, instead of calculating the actual utilization ratio. 

For example, on a 16GB system using 8GB of RAM, the system incorrectly displayed "8% RAM used" instead of the correct "50% RAM used".

## Changes Made
- Corrected the formula to calculate actual percentage: `(ram_used / ram_total) * 100`.
- Ensured the output accurately reflects true system utilization based on total capacity.