### PR TITLE
Fixed Battery Percentage Bug

### DIFF
--- a/.config/ags/widgets/bar/components/Utilities.tsx
+++ b/.config/ags/widgets/bar/components/Utilities.tsx
@@ -172,7 +172,7 @@ function Battery() {
       visible={createBinding(battery, "isPresent")}
       tooltipMarkup={createComputed(() => {
         const profile = powerprofiles.active_profile;
-        return `Battery: ${percent.peek()} \nProfile: ${profile}`;
+        return `Battery: ${percent} \nProfile: ${profile}`;
       })}
     >
       <box spacing={5} class="battery">

--- a/.config/ags/widgets/bar/components/Utilities.tsx
+++ b/.config/ags/widgets/bar/components/Utilities.tsx
@@ -170,10 +170,17 @@ function Battery() {
   return (
     <menubutton
       visible={createBinding(battery, "isPresent")}
-      tooltipMarkup={createComputed(() => {
-        const profile = powerprofiles.active_profile;
-        return `Battery: ${percent} \nProfile: ${profile}`;
-      })}
+      $={(self) => {
+        const updateTooltip = () => {
+          const currentPercent = battery.percentage;
+          const profile = powerprofiles.active_profile;
+          self.tooltip_markup = `Battery: ${Math.floor(currentPercent * 100)}% \nProfile: ${profile}`;
+        };
+        updateTooltip();
+
+        battery.connect("notify::percentage", updateTooltip);
+        powerprofiles.connect("notify::active-profile", updateTooltip);
+      }}
     >
       <box spacing={5} class="battery">
         <image iconName={createBinding(battery, "iconName")} />

--- a/.config/ags/widgets/bar/components/sub-components/Battery.tsx
+++ b/.config/ags/widgets/bar/components/sub-components/Battery.tsx
@@ -19,10 +19,17 @@ export default () => {
   return (
     <menubutton
       visible={createBinding(battery, "isPresent")}
-      tooltipMarkup={createComputed(() => {
-        const profile = powerprofiles.active_profile;
-        return `Battery: ${percent.peek()} \nProfile: ${profile}`;
-      })}
+      $={(self) => {
+        const updateTooltip = () => {
+          const currentPercent = battery.percentage;
+          const profile = powerprofiles.active_profile;
+          self.tooltip_markup = `Battery: ${Math.floor(currentPercent * 100)}% \nProfile: ${profile}`;
+        };
+        updateTooltip();
+
+        battery.connect("notify::percentage", updateTooltip);
+        powerprofiles.connect("notify::active-profile", updateTooltip);
+      }}
     >
       <box spacing={5} class="battery">
         <image iconName={createBinding(battery, "iconName")} />


### PR DESCRIPTION
# Fix: Battery pop-up tooltip not updating

Fixes a bug where the top bar battery hover pop-up would remain stuck at the startup percentage instead of updating dynamically. 

## Cause
The tooltip was using `percent.peek()`, which performs a one-time static read during the initial render without registering the binding as a reactive dependency.

## The Fix
This fix uses explicit GTK signal connections (`notify::percentage` and `notify::active-profile`) inside the `$` setup block to guarantee real-time updates.