### PR TITLE
feat: show all GPUs with kernel driver info in system resources monitor

### DIFF
--- a/.config/ags/interfaces/systemResources.interface.ts
+++ b/.config/ags/interfaces/systemResources.interface.ts
@@ -1,3 +1,12 @@
+export interface GpuStatInterface {
+  label: string;
+  driver: string;
+  load: number | null;
+  memoryUsedGB: number | null;
+  memoryTotalGB: number | null;
+  tempC: number | null;
+}
+
 export interface SystemResourcesInterface {
   cpuLoad: number;
   clockGHz: number;
@@ -6,9 +15,7 @@ export interface SystemResourcesInterface {
   ramTotalGB: number;
   ramUsedGB: number;
   ramFreeGB: number;
-  gpuLoad: number | null;
-  gpuMemoryUsedGB: number | null;
-  gpuTempC: number | null;
-  gpuLabel: string;
+  ramUsage: number;
+  gpus: GpuStatInterface[];
   updatedAt: string;
 }

--- a/.config/ags/scripts/system-resources-loop-ags.c
+++ b/.config/ags/scripts/system-resources-loop-ags.c
@@ -10,24 +10,24 @@ typedef struct {
     unsigned long long idle;
 } CPUStat;
 
-typedef enum {
-    GPU_NONE,
-    GPU_NVIDIA,
-    GPU_SYSFS
-} GPUType;
-
-static GPUType gpu_type = GPU_NONE;
-static int active_gpu_card_index = -1;
+#define MAX_GPUS 8
 
 typedef struct {
+    char label[96];
+    char driver[32];
     double load;
     double memory_used_gb;
+    double memory_total_gb;
     double temp_c;
     int has_load;
-    int has_memory;
+    int has_memory_used;
+    int has_memory_total;
     int has_temp;
-    const char *label;
-} GPUMetrics;
+} GPUInfo;
+
+static int nvidia_available = 0;
+static int sysfs_cards[MAX_GPUS];
+static int sysfs_card_count = 0;
 
 /* ---------------- CPU ---------------- */
 
@@ -159,26 +159,82 @@ static int get_ram_info(double *total_gb, double *used_gb, double *free_gb, doub
 
 /* ---------------- GPU ---------------- */
 
-static void detect_gpu() {
-    if (access("/usr/bin/nvidia-smi", X_OK) == 0 || access("/bin/nvidia-smi", X_OK) == 0) {
-        gpu_type = GPU_NVIDIA;
-        return;
-    }
+static void detect_gpus() {
+    nvidia_available = (access("/usr/bin/nvidia-smi", X_OK) == 0 ||
+                        access("/bin/nvidia-smi", X_OK) == 0);
 
     char path[256];
-    for (int i = 0; i < 8; i++) {
+    for (int i = 0; i < 8 && sysfs_card_count < MAX_GPUS; i++) {
         snprintf(path, sizeof(path), "/sys/class/drm/card%d/device/gpu_busy_percent", i);
         if (access(path, R_OK) == 0) {
-            gpu_type = GPU_SYSFS;
-            active_gpu_card_index = i;
+            sysfs_cards[sysfs_card_count++] = i;
+        }
+    }
+}
 
-            char vram_path[256];
-            snprintf(vram_path, sizeof(vram_path), "/sys/class/drm/card%d/device/mem_info_vram_used", i);
-            if (access(vram_path, R_OK) == 0) {
-                break;
+static int read_uevent_driver(int card_index, char *out, size_t out_size) {
+    char path[256];
+    snprintf(path, sizeof(path), "/sys/class/drm/card%d/device/uevent", card_index);
+    FILE *fp = fopen(path, "r");
+    if (!fp) return 0;
+
+    char line[128];
+    int found = 0;
+    while (fgets(line, sizeof(line), fp)) {
+        if (strncmp(line, "DRIVER=", 7) == 0) {
+            line[strcspn(line, "\n")] = '\0';
+            snprintf(out, out_size, "%s", line + 7);
+            found = 1;
+            break;
+        }
+    }
+    fclose(fp);
+    return found;
+}
+
+static int parse_metric(const char *token, double *out) {
+    while (*token == ' ') token++;
+    char *end = NULL;
+    double val = strtod(token, &end);
+    if (end == token) return 0;
+    *out = val;
+    return 1;
+}
+
+static void copy_label_sanitized(char *dst, size_t dst_size, const char *src) {
+    size_t j = 0;
+    while (*src == ' ') src++;
+    for (; *src && j + 1 < dst_size; src++) {
+        unsigned char c = (unsigned char)*src;
+        if (c == '"' || c == '\\' || c < 0x20) continue;
+        dst[j++] = (char)c;
+    }
+    while (j > 0 && dst[j - 1] == ' ') j--;
+    dst[j] = '\0';
+}
+
+/* "NVIDIA GeForce RTX 4080" -> "RTX 4080"; the vendor is already carried
+ * by the driver field. Keeps the original label if stripping empties it. */
+static void shorten_gpu_label(char *label, size_t label_size) {
+    static const char *prefixes[] = {
+        "NVIDIA ", "GeForce ", "AMD ", "Intel(R) ", "Intel ", "Radeon(TM) ",
+    };
+    char shortened[96];
+    snprintf(shortened, sizeof(shortened), "%s", label);
+
+    int changed = 1;
+    while (changed) {
+        changed = 0;
+        for (size_t i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++) {
+            size_t len = strlen(prefixes[i]);
+            if (strncmp(shortened, prefixes[i], len) == 0) {
+                memmove(shortened, shortened + len, strlen(shortened + len) + 1);
+                changed = 1;
             }
         }
     }
+
+    if (shortened[0] != '\0') snprintf(label, label_size, "%s", shortened);
 }
 
 static int read_gpu_temp_sysfs(int card_index, double *out) {
@@ -190,50 +246,87 @@ static int read_gpu_temp_sysfs(int card_index, double *out) {
     return 0;
 }
 
-static GPUMetrics get_gpu_metrics() {
-    GPUMetrics m = {0};
-    m.label = "GPU";
+static int collect_nvidia_gpus(GPUInfo *gpus, int count) {
+    FILE *fp = popen("nvidia-smi --query-gpu=name,utilization.gpu,memory.used,memory.total,temperature.gpu --format=csv,noheader,nounits 2>/dev/null", "r");
+    if (!fp) return count;
 
-    if (gpu_type == GPU_NVIDIA) {
-        FILE *fp = popen("nvidia-smi --query-gpu=utilization.gpu,memory.used,temperature.gpu --format=csv,noheader,nounits | head -n1", "r");
-        if (!fp) return m;
+    char line[256];
+    while (count < MAX_GPUS && fgets(line, sizeof(line), fp)) {
+        char *fields[5] = {0};
+        int nfields = 0;
+        char *cursor = line;
+        while (nfields < 5 && cursor) {
+            fields[nfields++] = cursor;
+            char *comma = strchr(cursor, ',');
+            if (comma) { *comma = '\0'; cursor = comma + 1; }
+            else cursor = NULL;
+        }
 
-        double util = 0.0, mem_mb = 0.0, temp = 0.0;
-        int parsed = fscanf(fp, " %lf , %lf , %lf", &util, &mem_mb, &temp);
-        pclose(fp);
-
-        m.label = "NVIDIA GPU";
-        if (parsed >= 1) { m.load = util; m.has_load = 1; }
-        if (parsed >= 2) { m.memory_used_gb = mem_mb / 1024.0; m.has_memory = 1; }
-        if (parsed >= 3) { m.temp_c = temp; m.has_temp = 1; }
-        return m;
-    }
-
-    if (gpu_type == GPU_SYSFS && active_gpu_card_index >= 0) {
-        char path[256];
+        GPUInfo g = {0};
         double val = 0.0;
 
-        m.label = "AMD/Intel GPU";
+        copy_label_sanitized(g.label, sizeof(g.label), fields[0]);
+        shorten_gpu_label(g.label, sizeof(g.label));
+        if (nfields > 1 && parse_metric(fields[1], &val)) { g.load = val; g.has_load = 1; }
+        if (nfields > 2 && parse_metric(fields[2], &val)) { g.memory_used_gb = val / 1024.0; g.has_memory_used = 1; }
+        if (nfields > 3 && parse_metric(fields[3], &val)) { g.memory_total_gb = val / 1024.0; g.has_memory_total = 1; }
+        if (nfields > 4 && parse_metric(fields[4], &val)) { g.temp_c = val; g.has_temp = 1; }
 
-        snprintf(path, sizeof(path), "/sys/class/drm/card%d/device/gpu_busy_percent", active_gpu_card_index);
-        if (read_double_from_file(path, &val)) {
-            m.load = val;
-            m.has_load = 1;
-        }
+        if (g.label[0] == '\0' || !g.has_load) continue;
 
-        snprintf(path, sizeof(path), "/sys/class/drm/card%d/device/mem_info_vram_used", active_gpu_card_index);
-        if (read_double_from_file(path, &val)) {
-            m.memory_used_gb = val / (1024.0 * 1024.0 * 1024.0);
-            m.has_memory = 1;
-        }
-
-        if (read_gpu_temp_sysfs(active_gpu_card_index, &val)) {
-            m.temp_c = val / 1000.0;
-            m.has_temp = 1;
-        }
+        snprintf(g.driver, sizeof(g.driver), "nvidia");
+        gpus[count++] = g;
     }
+    pclose(fp);
+    return count;
+}
 
-    return m;
+static int collect_sysfs_gpus(GPUInfo *gpus, int count) {
+    char path[256];
+    for (int i = 0; i < sysfs_card_count && count < MAX_GPUS; i++) {
+        int card = sysfs_cards[i];
+        GPUInfo g = {0};
+        double val = 0.0;
+
+        if (!read_uevent_driver(card, g.driver, sizeof(g.driver))) {
+            snprintf(g.driver, sizeof(g.driver), "unknown");
+        }
+
+        if (strcmp(g.driver, "amdgpu") == 0 || strcmp(g.driver, "radeon") == 0) {
+            snprintf(g.label, sizeof(g.label), "AMD GPU");
+        } else if (strcmp(g.driver, "i915") == 0 || strcmp(g.driver, "xe") == 0) {
+            snprintf(g.label, sizeof(g.label), "Intel GPU");
+        } else {
+            snprintf(g.label, sizeof(g.label), "GPU");
+        }
+
+        snprintf(path, sizeof(path), "/sys/class/drm/card%d/device/gpu_busy_percent", card);
+        if (read_double_from_file(path, &val)) { g.load = val; g.has_load = 1; }
+
+        snprintf(path, sizeof(path), "/sys/class/drm/card%d/device/mem_info_vram_used", card);
+        if (read_double_from_file(path, &val)) {
+            g.memory_used_gb = val / (1024.0 * 1024.0 * 1024.0);
+            g.has_memory_used = 1;
+        }
+
+        snprintf(path, sizeof(path), "/sys/class/drm/card%d/device/mem_info_vram_total", card);
+        if (read_double_from_file(path, &val)) {
+            g.memory_total_gb = val / (1024.0 * 1024.0 * 1024.0);
+            g.has_memory_total = 1;
+        }
+
+        if (read_gpu_temp_sysfs(card, &val)) { g.temp_c = val / 1000.0; g.has_temp = 1; }
+
+        gpus[count++] = g;
+    }
+    return count;
+}
+
+static int get_all_gpu_metrics(GPUInfo *gpus) {
+    int count = 0;
+    if (nvidia_available) count = collect_nvidia_gpus(gpus, count);
+    count = collect_sysfs_gpus(gpus, count);
+    return count;
 }
 
 /* ---------------- JSON OUTPUT ---------------- */
@@ -250,7 +343,7 @@ static void print_number_or_null(double value, int has_value, int decimals) {
 
 static void print_json(double cpu_load, double clock_ghz, int threads, double cpu_temp_c, int has_cpu_temp,
                        double ram_total_gb, double ram_used_gb, double ram_free_gb, double ram_usage,
-                       GPUMetrics gpu) {
+                       const GPUInfo *gpus, int gpu_count) {
     time_t now = time(NULL);
     struct tm *t = localtime(&now);
     char updated_at[32];
@@ -267,11 +360,19 @@ static void print_json(double cpu_load, double clock_ghz, int threads, double cp
     printf("\"ramFreeGB\":%.2f,", ram_free_gb);
     printf("\"ramUsage\":%.1f,", ram_usage);
 
-    printf("\"gpuLoad\":"); print_number_or_null(gpu.load, gpu.has_load, 1); printf(",");
-    printf("\"gpuMemoryUsedGB\":"); print_number_or_null(gpu.memory_used_gb, gpu.has_memory, 2); printf(",");
-    printf("\"gpuTempC\":"); print_number_or_null(gpu.temp_c, gpu.has_temp, 1); printf(",");
-    printf("\"gpuLabel\":\"%s\",", gpu.label);
-    
+    printf("\"gpus\":[");
+    for (int i = 0; i < gpu_count; i++) {
+        if (i > 0) printf(",");
+        printf("{\"label\":\"%s\",\"driver\":\"%s\",", gpus[i].label, gpus[i].driver);
+        printf("\"load\":"); print_number_or_null(gpus[i].load, gpus[i].has_load, 1); printf(",");
+        printf("\"memoryUsedGB\":"); print_number_or_null(gpus[i].memory_used_gb, gpus[i].has_memory_used, 2); printf(",");
+        printf("\"memoryTotalGB\":"); print_number_or_null(gpus[i].memory_total_gb, gpus[i].has_memory_total, 2); printf(",");
+        printf("\"tempC\":"); print_number_or_null(gpus[i].temp_c, gpus[i].has_temp, 1);
+        printf("}");
+    }
+    printf("],");
+
+
     printf("\"updatedAt\":\"%s\"", updated_at);
     printf("}\n");
     fflush(stdout);
@@ -288,10 +389,11 @@ static void collect_and_print(const CPUStat *old_stat, const CPUStat *new_stat) 
     double ram_total_gb = 0.0, ram_used_gb = 0.0, ram_free_gb = 0.0, ram_usage = 0.0;
     get_ram_info(&ram_total_gb, &ram_used_gb, &ram_free_gb, &ram_usage);
 
-    GPUMetrics gpu = get_gpu_metrics();
+    GPUInfo gpus[MAX_GPUS];
+    int gpu_count = get_all_gpu_metrics(gpus);
 
     print_json(cpu, clock_ghz, threads, cpu_temp_c, has_cpu_temp,
-               ram_total_gb, ram_used_gb, ram_free_gb, ram_usage, gpu);
+               ram_total_gb, ram_used_gb, ram_free_gb, ram_usage, gpus, gpu_count);
 }
 
 /* ---------------- MAIN ---------------- */
@@ -299,7 +401,7 @@ static void collect_and_print(const CPUStat *old_stat, const CPUStat *new_stat) 
 int main(int argc, char **argv) {
     int once = (argc > 1 && strcmp(argv[1], "--once") == 0);
 
-    detect_gpu();
+    detect_gpus();
 
     CPUStat old_stat = {0}, new_stat = {0};
 

--- a/.config/ags/scss/panel/right-panel/components/system-resources.scss
+++ b/.config/ags/scss/panel/right-panel/components/system-resources.scss
@@ -27,6 +27,11 @@
       .metric {
         font-size: 0.95em;
       }
+
+      .metric.driver {
+        color: $foreground-secondary;
+        font-size: 0.85em;
+      }
     }
 
     // .resource-column.cpu {

--- a/.config/ags/scss/panel/right-panel/components/system-resources.scss
+++ b/.config/ags/scss/panel/right-panel/components/system-resources.scss
@@ -7,11 +7,6 @@
       font-weight: 700;
       font-size: 1.05em;
     }
-
-    .refresh {
-      padding: 2px 8px;
-      border-radius: 8px;
-    }
   }
 
   .resource-columns {

--- a/.config/ags/widgets/bar/components/Utilities.tsx
+++ b/.config/ags/widgets/bar/components/Utilities.tsx
@@ -10,6 +10,7 @@ import AstalPowerProfiles from "gi://AstalPowerProfiles";
 import CircularProgress from "../../CircularProgress";
 import { timeout, Timer } from "ags/time";
 import SystemResources from "../../rightPanel/components/SystemResources";
+import { SystemResourcesInterface } from "../../../interfaces/systemResources.interface";
 import { connectPopoverEvents } from "../../../utils/window";
 
 import Hyprland from "gi://AstalHyprland";
@@ -113,6 +114,13 @@ function Tray() {
   );
 }
 
+function maxGpuLoad(res: SystemResourcesInterface | null): number | null {
+  const loads = (res?.gpus ?? [])
+    .map((gpu) => gpu.load)
+    .filter((load): load is number => load !== null);
+  return loads.length ? Math.max(...loads) : null;
+}
+
 function ResourceMonitor() {
   return (
     <button
@@ -194,9 +202,11 @@ function ResourceMonitor() {
               icon=""
             />
             <CircularProgress
-              visible={res?.gpuLoad !== undefined}
-              tooltipText={`GPU Usage ${res?.gpuLoad}%`}
-              value={res?.gpuLoad ? res?.gpuLoad / 100 : 0}
+              visible={(res?.gpus?.length ?? 0) > 0}
+              tooltipText={(res?.gpus ?? [])
+                .map((gpu) => `${gpu.driver}: ${gpu.load ?? "N/A"}%`)
+                .join(" | ")}
+              value={(maxGpuLoad(res) ?? 0) / 100}
               className="gpu-monitor"
               icon="󱤟"
             />

--- a/.config/ags/widgets/rightPanel/components/SystemResources.tsx
+++ b/.config/ags/widgets/rightPanel/components/SystemResources.tsx
@@ -1,40 +1,12 @@
 import { Gtk } from "ags/gtk4";
-import { Accessor, createState, With } from "ags";
-import { execAsync } from "ags/process";
+import { Accessor, With } from "ags";
 import { globalSettings, systemResourcesData } from "../../../variables";
-import GLib from "gi://GLib";
-
-interface SystemResourcesData {
-  cpuLoad: number;
-  clockGHz: number;
-  threads: number;
-  cpuTempC: number | null;
-  ramTotalGB: number;
-  ramUsedGB: number;
-  ramFreeGB: number;
-  gpuLoad: number | null;
-  gpuMemoryUsedGB: number | null;
-  gpuTempC: number | null;
-  gpuLabel: string;
-  updatedAt: string;
-}
-
-const POLL_MS = 5000;
-const SCRIPT_PATH = `/tmp/ags-${GLib.get_user_name()}/system-resources-loop-ags`;
 
 function formatOptionalNumber(
   value: number | null | undefined,
   suffix: string,
 ): string {
   return value === null || value === undefined ? "N/A" : `${value}${suffix}`;
-}
-
-function getNowTimeLabel(): string {
-  return new Date().toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
 }
 
 export default ({
@@ -44,21 +16,6 @@ export default ({
   className?: string | Accessor<string>;
   orientation?: Gtk.Orientation;
 }) => {
-  const [data, setData] = createState<SystemResourcesData>({
-    cpuLoad: 0,
-    clockGHz: 0,
-    threads: 0,
-    cpuTempC: null,
-    ramTotalGB: 0,
-    ramUsedGB: 0,
-    ramFreeGB: 0,
-    gpuLoad: null,
-    gpuMemoryUsedGB: null,
-    gpuTempC: null,
-    gpuLabel: "GPU",
-    updatedAt: "--:--:--",
-  });
-
   return (
     <box
       class={`system-resources ${className ?? ""}`}
@@ -84,10 +41,12 @@ export default ({
             <box
               class="resource-columns"
               spacing={10}
-              orientation={globalSettings(({ rightPanel }) =>
-                (orientation ?? rightPanel.width < 400)
-                  ? Gtk.Orientation.VERTICAL
-                  : Gtk.Orientation.HORIZONTAL,
+              orientation={globalSettings(
+                ({ rightPanel }) =>
+                  orientation ??
+                  (rightPanel.width < 400
+                    ? Gtk.Orientation.VERTICAL
+                    : Gtk.Orientation.HORIZONTAL),
               )}
             >
               <box

--- a/.config/ags/widgets/rightPanel/components/SystemResources.tsx
+++ b/.config/ags/widgets/rightPanel/components/SystemResources.tsx
@@ -9,6 +9,13 @@ function formatOptionalNumber(
   return value === null || value === undefined ? "N/A" : `${value}${suffix}`;
 }
 
+function formatGpuMemory(used: number | null, total: number | null): string {
+  if (used === null) return "N/A";
+  return total === null
+    ? `${used.toFixed(2)} GB`
+    : `${used.toFixed(2)}/${total.toFixed(2)} GB`;
+}
+
 export default ({
   className,
   orientation,
@@ -41,6 +48,7 @@ export default ({
             <box
               class="resource-columns"
               spacing={10}
+              homogeneous
               orientation={globalSettings(
                 ({ rightPanel }) =>
                   orientation ??
@@ -97,33 +105,36 @@ export default ({
                 />
               </box>
 
-              <box
-                class="resource-column gpu"
-                orientation={Gtk.Orientation.VERTICAL}
-                spacing={6}
-                hexpand
-              >
-                <label
-                  class="column-title"
-                  label={stats?.gpuLabel}
-                  xalign={0}
-                />
-                <label
-                  class="metric"
-                  label={`Load: ${formatOptionalNumber(stats?.gpuLoad, "%")}`}
-                  xalign={0}
-                />
-                <label
-                  class="metric"
-                  label={`Memory: ${formatOptionalNumber(stats?.gpuMemoryUsedGB, " GB")}`}
-                  xalign={0}
-                />
-                <label
-                  class="metric"
-                  label={`Temp: ${formatOptionalNumber(stats?.gpuTempC, "°C")}`}
-                  xalign={0}
-                />
-              </box>
+              {(stats?.gpus ?? []).map((gpu) => (
+                <box
+                  class="resource-column gpu"
+                  orientation={Gtk.Orientation.VERTICAL}
+                  spacing={6}
+                  hexpand
+                >
+                  <label class="column-title" label={gpu.label} xalign={0} />
+                  <label
+                    class="metric driver"
+                    label={`Driver: ${gpu.driver}`}
+                    xalign={0}
+                  />
+                  <label
+                    class="metric"
+                    label={`Load: ${formatOptionalNumber(gpu.load, "%")}`}
+                    xalign={0}
+                  />
+                  <label
+                    class="metric"
+                    label={`Memory: ${formatGpuMemory(gpu.memoryUsedGB, gpu.memoryTotalGB)}`}
+                    xalign={0}
+                  />
+                  <label
+                    class="metric"
+                    label={`Temp: ${formatOptionalNumber(gpu.tempC, "°C")}`}
+                    xalign={0}
+                  />
+                </box>
+              ))}
             </box>
           </box>
         )}


### PR DESCRIPTION
The resource monitor only ever shows one GPU: `detect_gpu()` bails early when nvidia-smi exists (so on my desktop the AMD iGPU is just invisible), and the nvidia path pipes through `head -n1`, dropping everything past GPU 0.

The collector now runs both the nvidia-smi and sysfs paths every cycle and emits a `gpus` array instead of the flat `gpu*` fields (interface + both consumers updated in the same commit). Each entry carries the kernel driver read from the device uevent, so the popup renders one card per GPU with its driver, and the bar ring tracks the busiest one with a per-GPU tooltip.

Tested on a 4080 + Raphael iGPU box, including with nvidia-smi hidden and with it present-but-broken to exercise the fallbacks. One caveat that already existed before: drivers without `gpu_busy_percent` (nouveau, most i915) still don't show up.

First commit is just dead-code cleanup in SystemResources.tsx since I was in there anyway.