### PR TITLE
fix: compact bar sizes to content instead of a padded startup width

### DIFF
--- a/.config/ags/widgets/bar/Bar.tsx
+++ b/.config/ags/widgets/bar/Bar.tsx
@@ -269,13 +269,34 @@ export default ({
   // ---------------------------------------------------------------------
   const barWidgets = {} as Record<BarStateName, Gtk.Widget>;
   const barWidths = {} as Record<BarStateName, number>;
+  const barPaddings = {} as Record<BarStateName, number>;
+
+  // Compact and expanded hold live content (workspaces, clock, tray) whose
+  // natural width changes at runtime — measure those at transition time.
+  // Every other page binds its own widthRequest to currentWidth, so a live
+  // measure would feed the current width back into itself; they keep the
+  // width cached at registration.
+  const DYNAMIC_STATES: BarStateName[] = ["compact", "expanded"];
+
+  function widthFor(state: BarStateName): number | undefined {
+    const widget = barWidgets[state];
+    if (!DYNAMIC_STATES.includes(state) || !widget) return barWidths[state];
+    const [, natural] = widget.measure(Gtk.Orientation.HORIZONTAL, -1);
+    return natural + (barPaddings[state] ?? 0);
+  }
 
   // Auto-animate width on every bar-state change — single source of truth.
   // barState is now driven by the priority resolver above; this block
   // doesn't need to know or care why it changed.
   barState.subscribe(() => {
     const state = barState.peek();
-    const target = barWidths[state];
+
+    // Re-parent the shared Information widget before measuring, so the
+    // target state is measured with its actual content in place.
+    if (state === "compact") moveInformationTo(compactInfoSlot);
+    else if (state === "expanded") moveInformationTo(expandedInfoSlot);
+
+    const target = widthFor(state);
     if (target === undefined) return;
 
     const current = currentWidth.peek();
@@ -288,9 +309,6 @@ export default ({
       setStackVisibleChild(state);
       timeout(100, () => animateWidth(target));
     }
-
-    if (state === "compact") moveInformationTo(compactInfoSlot);
-    else if (state === "expanded") moveInformationTo(expandedInfoSlot);
   });
 
   /**
@@ -309,6 +327,7 @@ export default ({
     width?: number;
   }) {
     barWidgets[name] = widget;
+    barPaddings[name] = padding;
     const [, natural] = widget.measure(Gtk.Orientation.HORIZONTAL, -1);
     barWidths[name] = natural + padding;
     return widget;
@@ -385,7 +404,7 @@ export default ({
             widget: CompactBar({
               components: [workspacesCompact, compactInfoSlot, battery, volume],
             }),
-            padding: 400,
+            padding: 40,
           }),
           "compact",
         );
@@ -397,7 +416,7 @@ export default ({
               center: expandedInfoSlot,
               end: utilities,
             }),
-            padding: 500,
+            padding: 60,
           }),
           "expanded",
         );
@@ -458,7 +477,7 @@ export default ({
           "network",
         );
 
-        setCurrentWidth(barWidths.compact);
+        setCurrentWidth(widthFor("compact") ?? barWidths.compact);
 
         const speaker = Wp.get_default()?.audio.defaultSpeaker!;
         watchTransient(

--- a/.config/ags/widgets/bar/Bar.tsx
+++ b/.config/ags/widgets/bar/Bar.tsx
@@ -29,6 +29,7 @@ import BrightnessWidget from "./components/sub-components/BrightnessWidget";
 import Recording from "./components/sub-components/Recording";
 import { isRecording } from "../../services/record.service";
 import AstalMpris from "gi://AstalMpris";
+import Hyprland from "gi://AstalHyprland";
 import PlayerWidget from "./components/sub-components/PlayerWidget";
 import NetworkWidget from "./barStates/NetworkWidget";
 import CompactBar from "./barStates/CompactBar";
@@ -36,6 +37,7 @@ import ExpandedBar from "./barStates/ExpandedBar";
 import SearchBar from "./barStates/SearchBar";
 
 const mpris = AstalMpris.get_default();
+const hyprland = Hyprland.get_default();
 
 export type BarStateName =
   | "compact"
@@ -285,6 +287,22 @@ export default ({
     return natural + (barPaddings[state] ?? 0);
   }
 
+  // Workspaces appearing/disappearing and client class changes alter the
+  // compact/expanded content width while the bar is resting — follow them.
+  // Debounced so GTK gets an idle cycle to relayout before the measure.
+  let widthRefreshTimer: Timer | null = null;
+  function queueWidthRefresh() {
+    widthRefreshTimer?.cancel();
+    widthRefreshTimer = timeout(150, () => {
+      widthRefreshTimer = null;
+      const state = barState.peek();
+      if (!DYNAMIC_STATES.includes(state)) return;
+      const target = widthFor(state);
+      if (target === undefined) return;
+      if (Math.abs(target - currentWidth.peek()) > 1) animateWidth(target);
+    });
+  }
+
   // Auto-animate width on every bar-state change — single source of truth.
   // barState is now driven by the priority resolver above; this block
   // doesn't need to know or care why it changed.
@@ -528,6 +546,18 @@ export default ({
       $={(self) => {
         setup(self);
         (self as any).monitorName = monitorName;
+
+        const unsubWorkspaces = createBinding(hyprland, "workspaces").subscribe(
+          queueWidthRefresh,
+        );
+        const unsubClients = createBinding(hyprland, "clients").subscribe(
+          queueWidthRefresh,
+        );
+        self.connect("destroy", () => {
+          unsubWorkspaces();
+          unsubClients();
+          widthRefreshTimer?.cancel();
+        });
       }}
     >
       <centerbox>

--- a/.config/ags/widgets/bar/barStates/CompactBar.tsx
+++ b/.config/ags/widgets/bar/barStates/CompactBar.tsx
@@ -1,13 +1,9 @@
 import { Gtk } from "ags/gtk4";
-import Information from "../components/Information";
-import Battery from "../components/sub-components/Battery";
-import { WorkspacesCompact } from "../components/Workspaces";
-import Volume from "../components/sub-components/Volume";
 
 export default ({ components }: { components: Gtk.Widget[] }) =>
   (
     <box spacing={5} halign={Gtk.Align.CENTER} hexpand>
-      {components.map((component, index) => (
+      {components.map((component) => (
         <box>{component}</box>
       ))}
     </box>


### PR DESCRIPTION
The compact pill is always much wider than its content: stack page widths are measured once at startup with a +400/+500px fudge, and CompactBar centers its content inside that frozen width, so the surplus shows up as empty pill on both sides.

Compact and expanded now re-measure at transition time (+40/60px for the crossfade), and a debounced re-measure follows Hyprland workspace/client changes so the resting width tracks reality. The other pages keep their cached widths on purpose — they bind `widthRequest` to the animated width, so live-measuring them would feed the current width back into its own target and grow forever.

Spring animation and the grow/shrink page-swap choreography are untouched. Verified live: width follows workspace churn, and no runaway from the volume/search/network states. The two padding constants are the knob if the crossfade needs more room on other setups.