### PR TITLE
feat: optional workspace number badges in bar

### DIFF
--- a/.config/ags/constants/settings.constants.ts
+++ b/.config/ags/constants/settings.constants.ts
@@ -178,6 +178,14 @@ export const defaultSettings: Settings = {
       min: 0,
       max: 1,
     },
+    workspaceNumbers: {
+      name: "Workspace Numbers",
+      value: false,
+      type: "bool",
+      min: 0,
+      max: 1,
+      tooltip: "Show a small workspace number next to each workspace icon",
+    },
     layout: barWidgetSelectors,
   },
   waifuWidget: {

--- a/.config/ags/interfaces/settings.interface.ts
+++ b/.config/ags/interfaces/settings.interface.ts
@@ -56,6 +56,7 @@ export interface Settings {
   dynamicThemeVariants: AGSSetting;
   bar: {
     orientation: AGSSetting;
+    workspaceNumbers: AGSSetting;
     layout: WidgetSelector[];
   };
   waifuWidget: {

--- a/.config/ags/widgets/bar/components/Workspaces.tsx
+++ b/.config/ags/widgets/bar/components/Workspaces.tsx
@@ -1,5 +1,9 @@
 import { Gtk } from "ags/gtk4";
-import { focusedWorkspace, specialWorkspace } from "../../../variables";
+import {
+  focusedWorkspace,
+  globalSettings,
+  specialWorkspace,
+} from "../../../variables";
 
 import Hyprland from "gi://AstalHyprland";
 import { createBinding, createComputed } from "ags";
@@ -25,6 +29,9 @@ const getWorkspaceIcon = (clientClass: string, fallbackIcon: string) => {
       ?.icon || fallbackIcon
   );
 };
+
+const workspaceNumberBadge = (id: number) =>
+  `<span size="x-small" rise="5000" alpha="65%"> ${id}</span>`;
 
 function Workspaces() {
   /**
@@ -115,16 +122,6 @@ function Workspaces() {
           previousWorkspaceStates.set(id, { isActive, isFocused });
 
           return classes.join(" ");
-        })}
-        label={createComputed(() => {
-          const isActive = workspace !== null;
-          if (!isActive) return emptyIcon;
-
-          const clients = createBinding(workspace!, "clients")();
-          const main_client = clients[0];
-          const client_class = main_client?.class || "empty";
-
-          return getWorkspaceIcon(client_class, extraWorkspaceIcon);
         })}
         onClicked={() =>
           hyprland.dispatch(`hl.dsp.focus({workspace = ${id}})`, "")
@@ -242,7 +239,25 @@ function Workspaces() {
 
           self.add_controller(dropTarget);
         }}
-      />
+      >
+        <label
+          useMarkup
+          label={createComputed(() => {
+            const numbered = globalSettings().bar.workspaceNumbers
+              .value as boolean;
+            const isActive = workspace !== null;
+            if (!isActive)
+              return numbered ? emptyIcon + workspaceNumberBadge(id) : emptyIcon;
+
+            const clients = createBinding(workspace!, "clients")();
+            const main_client = clients[0];
+            const client_class = main_client?.class || "empty";
+            const icon = getWorkspaceIcon(client_class, extraWorkspaceIcon);
+
+            return numbered ? icon + workspaceNumberBadge(id) : icon;
+          })}
+        />
+      </button>
     );
   };
 
@@ -428,14 +443,21 @@ export const WorkspacesCompact = () => {
                 const isFocused = currentWorkspace === id;
                 return isFocused ? "is-focused" : "is-unfocused";
               })}
-              label={createComputed(() => {
-                const clients = createBinding(workspace!, "clients")();
-                const main_client = clients[0];
-                const client_class = main_client?.class || "empty";
+            >
+              <label
+                useMarkup
+                label={createComputed(() => {
+                  const clients = createBinding(workspace!, "clients")();
+                  const main_client = clients[0];
+                  const client_class = main_client?.class || "empty";
+                  const icon = getWorkspaceIcon(client_class, "");
 
-                return getWorkspaceIcon(client_class, "");
-              })}
-            />
+                  return globalSettings().bar.workspaceNumbers.value
+                    ? icon + workspaceNumberBadge(id)
+                    : icon;
+                })}
+              />
+            </button>
           );
         }}
       </For>

--- a/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
+++ b/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
@@ -689,6 +689,10 @@ export default () => {
               setting={globalSettings.peek().bar.orientation}
             />
             <Setting
+              keyChanged="bar.workspaceNumbers"
+              setting={globalSettings.peek().bar.workspaceNumbers}
+            />
+            <Setting
               keyChanged="alwaysOnWidget.visibility"
               setting={globalSettings.peek().alwaysOnWidget.visibility}
             />


### PR DESCRIPTION
It's hard to tell which workspace is which when every button is an app icon or the same fallback dot — I kept jumping to the wrong one.

This adds a small superscript number badge next to each workspace button, in both the compact and expanded bar. Done with Pango markup (`x-small`, raised, dimmed), so no SCSS changes and existing button styling is untouched. Off by default behind a new "Workspace Numbers" toggle, so nothing changes visually unless you opt in.

Only structural change: the buttons use an explicit `<label useMarkup>` child now, since `Gtk.Button.label` can't render markup.