### PR TITLE
feat: side panel hot zone toggles, size, and preview

### DIFF
--- a/.config/ags/constants/settings.constants.ts
+++ b/.config/ags/constants/settings.constants.ts
@@ -191,12 +191,30 @@ export const defaultSettings: Settings = {
     lock: false,
     width: 250,
     widgets: rightPanelWidgetSelectors,
+    hotZone: {
+      name: "Right Panel Hot Zone",
+      value: true,
+      type: "bool",
+      min: 0,
+      max: 1,
+      tooltip:
+        "Reveal the right panel by hovering the screen edge or bar corner",
+    },
   },
   leftPanel: {
     exclusivity: true,
     lock: false,
     width: 400,
     widget: leftPanelWidgetSelectors[0],
+    hotZone: {
+      name: "Left Panel Hot Zone",
+      value: true,
+      type: "bool",
+      min: 0,
+      max: 1,
+      tooltip:
+        "Reveal the left panel by hovering the screen edge or bar corner",
+    },
   },
   chatBot: {
     api: chatBotApis[0],

--- a/.config/ags/constants/settings.constants.ts
+++ b/.config/ags/constants/settings.constants.ts
@@ -200,6 +200,14 @@ export const defaultSettings: Settings = {
       tooltip:
         "Reveal the right panel by hovering the screen edge or bar corner",
     },
+    hotZoneSize: {
+      name: "Right Panel Hot Zone Size",
+      value: 5,
+      type: "int",
+      min: 1,
+      max: 50,
+      tooltip: "Width in pixels of the right panel reveal area",
+    },
   },
   leftPanel: {
     exclusivity: true,
@@ -214,6 +222,14 @@ export const defaultSettings: Settings = {
       max: 1,
       tooltip:
         "Reveal the left panel by hovering the screen edge or bar corner",
+    },
+    hotZoneSize: {
+      name: "Left Panel Hot Zone Size",
+      value: 5,
+      type: "int",
+      min: 1,
+      max: 50,
+      tooltip: "Width in pixels of the left panel reveal area",
     },
   },
   chatBot: {

--- a/.config/ags/interfaces/settings.interface.ts
+++ b/.config/ags/interfaces/settings.interface.ts
@@ -69,6 +69,7 @@ export interface Settings {
     width: number;
     widgets: WidgetSelector[];
     lock: boolean;
+    hotZone: AGSSetting;
   };
   chatBot: {
     api: Api;
@@ -89,6 +90,7 @@ export interface Settings {
     width: number;
     lock: boolean;
     widget: WidgetSelector;
+    hotZone: AGSSetting;
   };
   crypto: {
     favorite: {

--- a/.config/ags/interfaces/settings.interface.ts
+++ b/.config/ags/interfaces/settings.interface.ts
@@ -70,6 +70,7 @@ export interface Settings {
     widgets: WidgetSelector[];
     lock: boolean;
     hotZone: AGSSetting;
+    hotZoneSize: AGSSetting;
   };
   chatBot: {
     api: Api;
@@ -91,6 +92,7 @@ export interface Settings {
     lock: boolean;
     widget: WidgetSelector;
     hotZone: AGSSetting;
+    hotZoneSize: AGSSetting;
   };
   crypto: {
     favorite: {

--- a/.config/ags/variables.ts
+++ b/.config/ags/variables.ts
@@ -72,6 +72,10 @@ export const layers = createBinding;
 export const globalMargin = 5;
 export const globalTransition = 300;
 
+// Flashed on by the settings "Preview Hot Zones" button so the otherwise
+// invisible panel reveal areas can be located on screen.
+export const [hotZonePreview, setHotZonePreview] = createState(false);
+
 export const date_less = createPoll(
   "",
   30000,

--- a/.config/ags/widgets/bar/Bar.tsx
+++ b/.config/ags/widgets/bar/Bar.tsx
@@ -517,8 +517,12 @@ export default ({
           $type="start"
           valign={Gtk.Align.START}
           halign={Gtk.Align.START}
-          widthRequest={5}
-          heightRequest={5}
+          widthRequest={globalSettings(
+            (s) => s.leftPanel.hotZoneSize.value as number,
+          )}
+          heightRequest={globalSettings(
+            (s) => s.leftPanel.hotZoneSize.value as number,
+          )}
           css={hotZonePreview((preview) =>
             preview ? "background-color: rgba(255, 85, 85, 0.4);" : "",
           )}
@@ -593,8 +597,12 @@ export default ({
           $type="end"
           valign={Gtk.Align.START}
           halign={Gtk.Align.END}
-          widthRequest={5}
-          heightRequest={5}
+          widthRequest={globalSettings(
+            (s) => s.rightPanel.hotZoneSize.value as number,
+          )}
+          heightRequest={globalSettings(
+            (s) => s.rightPanel.hotZoneSize.value as number,
+          )}
           css={hotZonePreview((preview) =>
             preview ? "background-color: rgba(255, 85, 85, 0.4);" : "",
           )}

--- a/.config/ags/widgets/bar/Bar.tsx
+++ b/.config/ags/widgets/bar/Bar.tsx
@@ -12,6 +12,7 @@ import {
   fullscreenClient,
   globalMargin,
   globalSettings,
+  hotZonePreview,
 } from "../../variables";
 import { getMonitorName } from "../../utils/monitor";
 import { WidgetSelector } from "../../interfaces/widgetSelector.interface";
@@ -518,9 +519,14 @@ export default ({
           halign={Gtk.Align.START}
           widthRequest={5}
           heightRequest={5}
+          css={hotZonePreview((preview) =>
+            preview ? "background-color: rgba(255, 85, 85, 0.4);" : "",
+          )}
         >
           <Gtk.EventControllerMotion
             onEnter={() => {
+              if (!(globalSettings.peek().leftPanel.hotZone.value as boolean))
+                return;
               if (!globalSettings.peek().leftPanel.lock) return;
               const leftPanel = app.get_window(
                 `left-panel-${monitorName}`,
@@ -589,9 +595,14 @@ export default ({
           halign={Gtk.Align.END}
           widthRequest={5}
           heightRequest={5}
+          css={hotZonePreview((preview) =>
+            preview ? "background-color: rgba(255, 85, 85, 0.4);" : "",
+          )}
         >
           <Gtk.EventControllerMotion
             onEnter={() => {
+              if (!(globalSettings.peek().rightPanel.hotZone.value as boolean))
+                return;
               if (!globalSettings.peek().rightPanel.lock) return;
               const rightPanel = app.get_window(
                 `right-panel-${monitorName}`,

--- a/.config/ags/widgets/leftPanel/LeftPanelHover.tsx
+++ b/.config/ags/widgets/leftPanel/LeftPanelHover.tsx
@@ -3,11 +3,7 @@ import { Gtk } from "ags/gtk4";
 import { Gdk } from "ags/gtk4";
 import { Astal } from "ags/gtk4";
 import { createComputed } from "gnim";
-import {
-  globalSettings,
-  hotZonePreview,
-  setGlobalSetting,
-} from "../../variables";
+import { globalSettings, hotZonePreview } from "../../variables";
 import app from "ags/gtk4/app";
 import { getMonitorName } from "../../utils/monitor";
 import { showWindow } from "../../utils/window";

--- a/.config/ags/widgets/leftPanel/LeftPanelHover.tsx
+++ b/.config/ags/widgets/leftPanel/LeftPanelHover.tsx
@@ -3,7 +3,11 @@ import { Gtk } from "ags/gtk4";
 import { Gdk } from "ags/gtk4";
 import { Astal } from "ags/gtk4";
 import { createComputed } from "gnim";
-import { globalSettings, setGlobalSetting } from "../../variables";
+import {
+  globalSettings,
+  hotZonePreview,
+  setGlobalSetting,
+} from "../../variables";
 import app from "ags/gtk4/app";
 import { getMonitorName } from "../../utils/monitor";
 import { showWindow } from "../../utils/window";
@@ -27,7 +31,10 @@ export default ({
       }
       exclusivity={Astal.Exclusivity.IGNORE}
       layer={Astal.Layer.TOP}
-      visible={globalSettings(({ leftPanel }) => !leftPanel.lock)}
+      visible={globalSettings(
+        ({ leftPanel }) =>
+          !leftPanel.lock && (leftPanel.hotZone.value as boolean),
+      )}
       $={(self) => {
         setup(self);
         const motion = new Gtk.EventControllerMotion();
@@ -37,7 +44,13 @@ export default ({
         self.add_controller(motion);
       }}
     >
-      <box css="min-width: 5px; background-color: rgba(0,0,0,0.01);" />
+      <box
+        css={hotZonePreview((preview) =>
+          preview
+            ? "min-width: 5px; background-color: rgba(255, 85, 85, 0.4);"
+            : "min-width: 5px; background-color: rgba(0,0,0,0.01);",
+        )}
+      />
     </window>
   );
 };

--- a/.config/ags/widgets/leftPanel/LeftPanelHover.tsx
+++ b/.config/ags/widgets/leftPanel/LeftPanelHover.tsx
@@ -45,11 +45,13 @@ export default ({
       }}
     >
       <box
-        css={hotZonePreview((preview) =>
-          preview
-            ? "min-width: 5px; background-color: rgba(255, 85, 85, 0.4);"
-            : "min-width: 5px; background-color: rgba(0,0,0,0.01);",
-        )}
+        css={createComputed(() => {
+          const size = globalSettings().leftPanel.hotZoneSize.value as number;
+          const background = hotZonePreview()
+            ? "rgba(255, 85, 85, 0.4)"
+            : "rgba(0,0,0,0.01)";
+          return `min-width: ${size}px; background-color: ${background};`;
+        })}
       />
     </window>
   );

--- a/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
+++ b/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
@@ -694,8 +694,16 @@ export default () => {
               setting={globalSettings.peek().leftPanel.hotZone}
             />
             <Setting
+              keyChanged="leftPanel.hotZoneSize"
+              setting={globalSettings.peek().leftPanel.hotZoneSize}
+            />
+            <Setting
               keyChanged="rightPanel.hotZone"
               setting={globalSettings.peek().rightPanel.hotZone}
+            />
+            <Setting
+              keyChanged="rightPanel.hotZoneSize"
+              setting={globalSettings.peek().rightPanel.hotZoneSize}
             />
             <button
               class="hot-zone-preview"

--- a/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
+++ b/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
@@ -15,6 +15,7 @@ import {
   globalSettings,
   setGlobalSetting,
   setGlobalSettings,
+  setHotZonePreview,
 } from "../../../variables";
 import { WidgetSelector } from "../../../interfaces/widgetSelector.interface";
 import { refreshCss } from "../../../utils/scss";
@@ -687,6 +688,23 @@ export default () => {
             <Setting
               keyChanged="bar.orientation"
               setting={globalSettings.peek().bar.orientation}
+            />
+            <Setting
+              keyChanged="leftPanel.hotZone"
+              setting={globalSettings.peek().leftPanel.hotZone}
+            />
+            <Setting
+              keyChanged="rightPanel.hotZone"
+              setting={globalSettings.peek().rightPanel.hotZone}
+            />
+            <button
+              class="hot-zone-preview"
+              label="Preview Hot Zones"
+              tooltipText="Highlight the panel reveal areas for a few seconds"
+              onClicked={() => {
+                setHotZonePreview(true);
+                timeout(3000, () => setHotZonePreview(false));
+              }}
             />
             <Setting
               keyChanged="alwaysOnWidget.visibility"

--- a/.config/ags/widgets/rightPanel/RightPanelHover.tsx
+++ b/.config/ags/widgets/rightPanel/RightPanelHover.tsx
@@ -3,7 +3,11 @@ import { Gtk } from "ags/gtk4";
 import { Gdk } from "ags/gtk4";
 import { Astal } from "ags/gtk4";
 import { createComputed } from "gnim";
-import { globalSettings, setGlobalSetting } from "../../variables";
+import {
+  globalSettings,
+  hotZonePreview,
+  setGlobalSetting,
+} from "../../variables";
 import app from "ags/gtk4/app";
 import { getMonitorName } from "../../utils/monitor";
 
@@ -26,7 +30,10 @@ export default ({
       }
       exclusivity={Astal.Exclusivity.IGNORE}
       layer={Astal.Layer.TOP}
-      visible={globalSettings(({ rightPanel }) => !rightPanel.lock)}
+      visible={globalSettings(
+        ({ rightPanel }) =>
+          !rightPanel.lock && (rightPanel.hotZone.value as boolean),
+      )}
       $={(self) => {
         setup(self);
         const motion = new Gtk.EventControllerMotion();
@@ -36,7 +43,13 @@ export default ({
         self.add_controller(motion);
       }}
     >
-      <box css="min-width: 5px; background-color: rgba(0,0,0,0.01);" />
+      <box
+        css={hotZonePreview((preview) =>
+          preview
+            ? "min-width: 5px; background-color: rgba(255, 85, 85, 0.4);"
+            : "min-width: 5px; background-color: rgba(0,0,0,0.01);",
+        )}
+      />
     </window>
   );
 };

--- a/.config/ags/widgets/rightPanel/RightPanelHover.tsx
+++ b/.config/ags/widgets/rightPanel/RightPanelHover.tsx
@@ -3,11 +3,7 @@ import { Gtk } from "ags/gtk4";
 import { Gdk } from "ags/gtk4";
 import { Astal } from "ags/gtk4";
 import { createComputed } from "gnim";
-import {
-  globalSettings,
-  hotZonePreview,
-  setGlobalSetting,
-} from "../../variables";
+import { globalSettings, hotZonePreview } from "../../variables";
 import app from "ags/gtk4/app";
 import { getMonitorName } from "../../utils/monitor";
 

--- a/.config/ags/widgets/rightPanel/RightPanelHover.tsx
+++ b/.config/ags/widgets/rightPanel/RightPanelHover.tsx
@@ -44,11 +44,13 @@ export default ({
       }}
     >
       <box
-        css={hotZonePreview((preview) =>
-          preview
-            ? "min-width: 5px; background-color: rgba(255, 85, 85, 0.4);"
-            : "min-width: 5px; background-color: rgba(0,0,0,0.01);",
-        )}
+        css={createComputed(() => {
+          const size = globalSettings().rightPanel.hotZoneSize.value as number;
+          const background = hotZonePreview()
+            ? "rgba(255, 85, 85, 0.4)"
+            : "rgba(0,0,0,0.01)";
+          return `min-width: ${size}px; background-color: ${background};`;
+        })}
       />
     </window>
   );


### PR DESCRIPTION
The screen-edge strips and bar corners that reveal the side panels are invisible, fixed at 5px, and can't be turned off - easy to trigger accidentally and hard to even locate.

Each panel gets a "Hot Zone" toggle (default on, current behavior) that disables both its edge strip and its bar corner, plus a size slider (1-50px) driving the strip width and corner dimensions. A "Preview Hot Zones" button in settings tints all reveal areas for a few seconds so you can see what you're configuring.

Settings-driven throughout (`leftPanel.hotZone` / `hotZoneSize` and the rightPanel equivalents), migrated automatically for existing users by the settings deep-merge.