### PR TITLE
fix(keybinds): truncate long descriptions, prevent horizontal scroll, and ignore auto-generated files

### DIFF
--- a/.config/ags/scripts/get-keybinds.sh
+++ b/.config/ags/scripts/get-keybinds.sh
@@ -51,6 +51,19 @@ main_mod="SUPER"
 any_category_printed=false
 current_category=""
 
+# Files that shouldn't be treated as keybind sources even if they live in custom/
+blacklist=("monitors.lua" "monitors.conf")
+
+is_blacklisted() {
+  local base
+  base="$(basename "$1")"
+  local item
+  for item in "${blacklist[@]}"; do
+    [[ "$base" == "$item" ]] && return 0
+  done
+  return 1
+}
+
 echo "{"
 
 # 1. First stage: Parse the main bind.lua file
@@ -139,6 +152,7 @@ if [[ -d "$custom_dir" ]]; then
   while IFS= read -r cfile; do
     [[ "$cfile" == *.lua ]] || continue
     [[ -f "$cfile" ]] || continue
+    is_blacklisted "$cfile" && continue
 
     local_main_mod="$main_mod"
     current_comment=""

--- a/.config/ags/widgets/leftPanel/components/KeyBinds.tsx
+++ b/.config/ags/widgets/leftPanel/components/KeyBinds.tsx
@@ -1,4 +1,5 @@
 import { Gtk } from "ags/gtk4";
+import Pango from "gi://Pango";
 import KeyBind from "../../KeyBind";
 import { execAsync } from "ags/process";
 import { createState, For, With } from "gnim";
@@ -18,6 +19,8 @@ export default () => {
     <scrolledwindow
       hexpand
       vexpand
+      hscrollbarPolicy={Gtk.PolicyType.NEVER}
+      vscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
       $={(self) => {
         execAsync(
           `bash -c "${GLib.get_home_dir()}/.config/ags/scripts/get-keybinds.sh"`,
@@ -49,6 +52,9 @@ export default () => {
                 <label
                   class="keybind-category-title"
                   label={category}
+                  tooltipText={category}
+                  ellipsize={Pango.EllipsizeMode.END}
+                  maxWidthChars={22}
                   xalign={0}
                 />
                 {binds.map((bind) => (
@@ -56,7 +62,9 @@ export default () => {
                     <label
                       class="keybind-description"
                       label={bind.description}
-                      wrap
+                      tooltipText={bind.description}
+                      ellipsize={Pango.EllipsizeMode.END}
+                      maxWidthChars={22}
                       hexpand
                       xalign={0}
                     />


### PR DESCRIPTION
- Add Pango ellipsize and maxWidthChars to description and category labels
- Set hscrollbarPolicy to NEVER on KeyBinds ScrolledWindow
- Add tooltips with full text on hover for truncated labels
- Blacklist nwg-displays auto-generated files in get-keybinds.sh