### PR TITLE
feat(bar): add keyboard layout indicator widget

### DIFF
--- a/.config/ags/scss/bar/bar.scss
+++ b/.config/ags/scss/bar/bar.scss
@@ -11,7 +11,8 @@
 
   &.compact {
     button,
-    .custom-revealer {
+    .custom-revealer,
+    .keyboard-layout {
       background-color: transparent;
     }
 

--- a/.config/ags/scss/bar/information.scss
+++ b/.config/ags/scss/bar/information.scss
@@ -10,6 +10,11 @@
     }
   }
 
+  .keyboard-layout {
+    @include module;
+    min-width: 2.2em;
+  }
+
   .client-title {
     @include module;
   }

--- a/.config/ags/services/keyboard-layout.ts
+++ b/.config/ags/services/keyboard-layout.ts
@@ -10,14 +10,42 @@ type KeyboardDevice = {
   main?: boolean;
 };
 
+export function findHyprlandSignature(): string | null {
+  const envSignature = GLib.getenv("HYPRLAND_INSTANCE_SIGNATURE");
+  if (envSignature) return envSignature;
+
+  const hyprDir = Gio.File.new_for_path(`${GLib.get_user_runtime_dir()}/hypr`);
+  try {
+    const enumerator = hyprDir.enumerate_children(
+      "standard::name,standard::type",
+      Gio.FileQueryInfoFlags.NONE,
+      null,
+    );
+    let info: Gio.FileInfo | null;
+    let found: string | null = null;
+    while ((info = enumerator.next_file(null))) {
+      if (info.get_file_type() === Gio.FileType.DIRECTORY) {
+        found = info.get_name();
+      }
+    }
+    enumerator.close(null);
+    return found;
+  } catch {
+    return null;
+  }
+}
+
+export function hyprctlCommand(...args: string[]): string[] {
+  const signature = findHyprlandSignature();
+  return signature ? ["hyprctl", "-i", signature, ...args] : ["hyprctl", ...args];
+}
+
 export const [keyboardLayout, setKeyboardLayout] = createState("");
 export const [keyboardLayoutName, setKeyboardLayoutName] = createState("");
 
 export const [deviceLayouts, setDeviceLayouts] = createState<
   Record<string, { layout: string; layoutName: string }>
 >({});
-
-let mainDeviceName = "";
 
 const XKB_BASE_LIST_PATH = "/usr/share/X11/xkb/rules/base.lst";
 
@@ -96,7 +124,7 @@ export function flagEmoji(code: string): string | null {
 
 void loadLayoutCodes().then((map) => {
   layoutCodes = map;
-  if (lastRawLayoutName) setActiveLayout(lastRawLayoutName, mainDeviceName || undefined);
+  if (lastRawLayoutName) setActiveLayout(lastRawLayoutName);
 });
 
 function setActiveLayout(rawName: string, device?: string) {
@@ -112,28 +140,31 @@ function setActiveLayout(rawName: string, device?: string) {
     }));
   }
 
-  if (!mainDeviceName || !device || device === mainDeviceName) {
-    lastRawLayoutName = normalized;
-    setKeyboardLayoutName(normalized);
-    setKeyboardLayout(code);
-  }
+  lastRawLayoutName = normalized;
+  setKeyboardLayoutName(normalized);
+  setKeyboardLayout(code);
 }
 
 async function loadInitialLayout() {
   try {
-    const output = await execAsync(["hyprctl", "devices", "-j"]);
+    const output = await execAsync(hyprctlCommand("devices", "-j"));
     const devices = JSON.parse(output) as { keyboards?: KeyboardDevice[] };
     const keyboards = devices.keyboards ?? [];
     const mainKeyboard = keyboards.find((device) => device.main) ?? keyboards[0];
 
-    mainDeviceName = mainKeyboard?.name ?? "";
     if (mainKeyboard?.active_keymap) {
-      setActiveLayout(mainKeyboard.active_keymap, mainDeviceName || undefined);
+      setActiveLayout(mainKeyboard.active_keymap, mainKeyboard.name);
     }
 
     for (const kb of keyboards) {
-      if (kb.name && kb.name !== mainDeviceName && kb.active_keymap) {
-        setActiveLayout(kb.active_keymap, kb.name);
+      if (kb.name && kb.name !== mainKeyboard?.name && kb.active_keymap) {
+        setDeviceLayouts((prev) => ({
+          ...prev,
+          [kb.name!]: {
+            layout: resolveCode(kb.active_keymap!.trim()),
+            layoutName: kb.active_keymap!.trim(),
+          },
+        }));
       }
     }
   } catch (error) {
@@ -222,7 +253,7 @@ function readNextLine() {
 }
 
 function watchLayoutChanges() {
-  const signature = GLib.getenv("HYPRLAND_INSTANCE_SIGNATURE");
+  const signature = findHyprlandSignature();
   if (!signature) {
     scheduleReconnect();
     return;

--- a/.config/ags/services/keyboard-layout.ts
+++ b/.config/ags/services/keyboard-layout.ts
@@ -1,0 +1,266 @@
+import { createState } from "ags";
+import { execAsync } from "ags/process";
+import { timeout } from "ags/time";
+import GLib from "gi://GLib";
+import Gio from "gi://Gio";
+
+type KeyboardDevice = {
+  name?: string;
+  active_keymap?: string;
+  main?: boolean;
+};
+
+export const [keyboardLayout, setKeyboardLayout] = createState("");
+export const [keyboardLayoutName, setKeyboardLayoutName] = createState("");
+
+export const [deviceLayouts, setDeviceLayouts] = createState<
+  Record<string, { layout: string; layoutName: string }>
+>({});
+
+let mainDeviceName = "";
+
+const XKB_BASE_LIST_PATH = "/usr/share/X11/xkb/rules/base.lst";
+
+let layoutCodes: Map<string, string> | null = null;
+let lastRawLayoutName = "";
+
+function parseXkbSection(
+  text: string,
+  section: "layout" | "variant",
+  onEntry: (code: string, rest: string) => void,
+) {
+  const lines = text.split("\n");
+  let inSection = false;
+  for (const line of lines) {
+    if (line === `! ${section}`) {
+      inSection = true;
+      continue;
+    }
+    if (!inSection) continue;
+    if (line.startsWith("!")) break;
+    const trimmed = line.trim();
+    if (trimmed === "") break;
+    const spaceIndex = trimmed.indexOf(" ");
+    if (spaceIndex === -1) continue;
+    onEntry(trimmed.slice(0, spaceIndex), trimmed.slice(spaceIndex + 1).trim());
+  }
+}
+
+function loadLayoutCodes(): Promise<Map<string, string>> {
+  return new Promise((resolve) => {
+    const map = new Map<string, string>();
+    const file = Gio.File.new_for_path(XKB_BASE_LIST_PATH);
+
+    file.load_contents_async(null, (_source, result) => {
+      try {
+        const [, contents] = file.load_contents_finish(result);
+        const text = new TextDecoder("utf-8").decode(contents);
+
+        parseXkbSection(text, "layout", (code, description) => {
+          if (!map.has(description)) map.set(description, code.toUpperCase());
+        });
+
+        parseXkbSection(text, "variant", (_variantCode, rest) => {
+          const sep = rest.indexOf(":");
+          if (sep === -1) return;
+          const base = rest.slice(0, sep).trim();
+          const description = rest.slice(sep + 1).trim();
+          if (!map.has(description)) map.set(description, base.toUpperCase());
+        });
+      } catch (error) {
+        printerr(
+          `keyboard-layout: could not read ${XKB_BASE_LIST_PATH}: ${error}`,
+        );
+      }
+      resolve(map);
+    });
+  });
+}
+
+function resolveCode(name: string): string {
+  return layoutCodes?.get(name) ?? name.slice(0, 2).toUpperCase();
+}
+
+void loadLayoutCodes().then((map) => {
+  layoutCodes = map;
+  if (lastRawLayoutName) setActiveLayout(lastRawLayoutName, mainDeviceName || undefined);
+});
+
+function setActiveLayout(rawName: string, device?: string) {
+  const normalized = rawName.trim();
+  if (!normalized) return;
+
+  const code = resolveCode(normalized);
+
+  if (device) {
+    setDeviceLayouts((prev) => ({
+      ...prev,
+      [device]: { layout: code, layoutName: normalized },
+    }));
+  }
+
+  if (!mainDeviceName || !device || device === mainDeviceName) {
+    lastRawLayoutName = normalized;
+    setKeyboardLayoutName(normalized);
+    setKeyboardLayout(code);
+  }
+}
+
+async function loadInitialLayout() {
+  try {
+    const output = await execAsync(["hyprctl", "devices", "-j"]);
+    const devices = JSON.parse(output) as { keyboards?: KeyboardDevice[] };
+    const keyboards = devices.keyboards ?? [];
+    const mainKeyboard = keyboards.find((device) => device.main) ?? keyboards[0];
+
+    mainDeviceName = mainKeyboard?.name ?? "";
+    if (mainKeyboard?.active_keymap) {
+      setActiveLayout(mainKeyboard.active_keymap, mainDeviceName || undefined);
+    }
+
+    for (const kb of keyboards) {
+      if (kb.name && kb.name !== mainDeviceName && kb.active_keymap) {
+        setActiveLayout(kb.active_keymap, kb.name);
+      }
+    }
+  } catch (error) {
+    printerr(`Unable to read the active keyboard layout: ${error}`);
+  }
+}
+
+let socket: Gio.Socket | null = null;
+let connection: Gio.SocketConnection | null = null;
+let dataStream: Gio.DataInputStream | null = null;
+let cancellable: Gio.Cancellable | null = null;
+let connecting = false;
+let watcherStarted = false;
+let reconnectAttempt = 0;
+let reconnectTimer: ReturnType<typeof timeout> | null = null;
+const MAX_BACKOFF_MS = 30_000;
+
+function stopWatcher() {
+  if (reconnectTimer) {
+    reconnectTimer.cancel?.();
+    reconnectTimer = null;
+  }
+  cancellable?.cancel();
+  cancellable = null;
+
+  try {
+    dataStream?.close(null);
+  } catch {
+  }
+  dataStream = null;
+
+  try {
+    connection?.close(null);
+  } catch {
+  }
+  connection = null;
+
+  try {
+    socket?.close();
+  } catch {
+  }
+  socket = null;
+  connecting = false;
+}
+
+function scheduleReconnect() {
+  reconnectAttempt += 1;
+  const delay = Math.min(1000 * 2 ** (reconnectAttempt - 1), MAX_BACKOFF_MS);
+  printerr(
+    `keyboard-layout: event socket down, retrying in ${delay}ms (attempt ${reconnectAttempt})`,
+  );
+  reconnectTimer = timeout(delay, () => {
+    reconnectTimer = null;
+    watchLayoutChanges();
+  });
+}
+
+function handleEvent(line: string) {
+  if (!line.startsWith("activelayout>>")) return;
+  const [, payload] = line.split(">>", 2);
+  const separator = payload.indexOf(",");
+  if (separator === -1) return;
+  const device = payload.slice(0, separator);
+  const layoutName = payload.slice(separator + 1);
+  setActiveLayout(layoutName, device);
+}
+
+function readNextLine() {
+  if (!dataStream || !cancellable) return;
+  const stream = dataStream;
+  const token = cancellable;
+
+  stream.read_line_async(GLib.PRIORITY_DEFAULT, token, (_source, result) => {
+    if (token.is_cancelled()) return;
+    try {
+      const [line] = stream.read_line_finish_utf8(result);
+      if (line === null) throw new Error("event socket closed (EOF)");
+      handleEvent(line);
+      readNextLine();
+    } catch (error) {
+      printerr(`keyboard-layout: event socket read failed: ${error}`);
+      stopWatcher();
+      scheduleReconnect();
+    }
+  });
+}
+
+function watchLayoutChanges() {
+  const signature = GLib.getenv("HYPRLAND_INSTANCE_SIGNATURE");
+  if (!signature) {
+    scheduleReconnect();
+    return;
+  }
+
+  if (socket || connecting) return;
+  connecting = true;
+
+  const socketPath = `${GLib.get_user_runtime_dir()}/hypr/${signature}/.socket2.sock`;
+
+  try {
+    const address = new Gio.UnixSocketAddress({ path: socketPath });
+    const newSocket = Gio.Socket.new(
+      Gio.SocketFamily.UNIX,
+      Gio.SocketType.STREAM,
+      Gio.SocketProtocol.DEFAULT,
+    );
+
+    newSocket.connect(address, null);
+
+    socket = newSocket;
+    connection = socket.connection_factory_create_connection();
+    cancellable = new Gio.Cancellable();
+    dataStream = new Gio.DataInputStream({
+      base_stream: connection.get_input_stream(),
+      close_base_stream: true,
+    });
+
+    reconnectAttempt = 0;
+    connecting = false;
+    readNextLine();
+  } catch (error) {
+    connecting = false;
+    socket = null;
+    connection = null;
+    dataStream = null;
+    printerr(`keyboard-layout: failed to connect to event socket: ${error}`);
+    scheduleReconnect();
+  }
+}
+
+export function startKeyboardLayoutWatcher() {
+  if (watcherStarted) return;
+  watcherStarted = true;
+  void loadInitialLayout();
+  watchLayoutChanges();
+}
+
+export function stopKeyboardLayoutWatcher() {
+  watcherStarted = false;
+  stopWatcher();
+}
+
+startKeyboardLayoutWatcher();

--- a/.config/ags/services/keyboard-layout.ts
+++ b/.config/ags/services/keyboard-layout.ts
@@ -81,6 +81,19 @@ function resolveCode(name: string): string {
   return layoutCodes?.get(name) ?? name.slice(0, 2).toUpperCase();
 }
 
+export function flagEmoji(code: string): string | null {
+  const upper = code.toUpperCase();
+  if (upper.length !== 2) return null;
+  const REGIONAL_INDICATOR_A = 0x1f1e6;
+  const points = [...upper].map(
+    (char) => REGIONAL_INDICATOR_A + (char.charCodeAt(0) - 65),
+  );
+  const valid = points.every(
+    (point) => point >= REGIONAL_INDICATOR_A && point <= REGIONAL_INDICATOR_A + 25,
+  );
+  return valid ? String.fromCodePoint(...points) : null;
+}
+
 void loadLayoutCodes().then((map) => {
   layoutCodes = map;
   if (lastRawLayoutName) setActiveLayout(lastRawLayoutName, mainDeviceName || undefined);

--- a/.config/ags/widgets/bar/components/Information.tsx
+++ b/.config/ags/widgets/bar/components/Information.tsx
@@ -30,6 +30,7 @@ import { connectPopoverEvents } from "../../../utils/window";
 import PlayerWidget, {
   playablePlayers,
 } from "./sub-components/PlayerWidget";
+import KeyboardLayout from "./sub-components/KeyboardLayout";
 
 const mpris = AstalMpris.get_default();
 
@@ -80,6 +81,7 @@ export default ({ halign }: { halign?: Gtk.Align | Accessor<Gtk.Align> }) => {
 
       {WeatherButton()}
       <Clock />
+      <KeyboardLayout />
       <Bandwidth />
       <box>
         <With value={globalSettings(({ crypto }) => crypto.favorite)}>

--- a/.config/ags/widgets/bar/components/sub-components/KeyboardLayout.tsx
+++ b/.config/ags/widgets/bar/components/sub-components/KeyboardLayout.tsx
@@ -1,0 +1,52 @@
+import { createState, createComputed } from "ags";
+import { Gtk } from "ags/gtk4";
+import { execAsync } from "ags/process";
+import {
+  keyboardLayout,
+  keyboardLayoutName,
+  flagEmoji,
+} from "../../../../services/keyboard-layout";
+import { Eventbox } from "../../../Custom/Eventbox";
+
+export default function KeyboardLayout() {
+  const [showFlag, setShowFlag] = createState(false);
+
+  const displayLabel = createComputed(
+    [keyboardLayout, showFlag],
+    (layout, flag) => {
+      if (!flag) return layout;
+      return flagEmoji(layout) ?? layout;
+    },
+  );
+
+  return (
+    <box
+      $={(self) => {
+        const rightClick = new Gtk.GestureClick({ button: 3 });
+        rightClick.connect("pressed", () => setShowFlag((prev) => !prev));
+        self.add_controller(rightClick);
+      }}
+    >
+      <Eventbox
+        tooltipText={keyboardLayoutName}
+        onClick={() => {
+          void execAsync([
+            "hyprctl",
+            "switchxkblayout",
+            "current",
+            "next",
+          ]).catch((error) =>
+            printerr(`keyboard-layout: failed to switch layout: ${error}`),
+          );
+        }}
+      >
+        <label
+          class="keyboard-layout"
+          label={displayLabel}
+          visible={keyboardLayout((layout) => layout.length > 0)}
+          valign={Gtk.Align.CENTER}
+        />
+      </Eventbox>
+    </box>
+  );
+}


### PR DESCRIPTION
Add a keyboard layout indicator to the bar, showing the active xkb layout for the main keyboard and updating live as it changes.

Implementation notes:

- Layout changes are tracked by connecting to Hyprland's event socket
  and picking up "activelayout>>" events live. The bar reflects
  whichever device fired most recently rather than gating on a single
  "main" device: `hyprctl devices -j` doesn't always have the main
  flag settled right after boot, and in practice only a real keyboard
  ever emits these events anyway (auxiliary HID interfaces like
  consumer/system-control endpoints don't). Every device's layout is
  still tracked individually via `deviceLayouts` for a future
  per-device UI.

- The short code shown in the bar (e.g. "US", "RU") is resolved by
  parsing /usr/share/X11/xkb/rules/base.lst at startup, so it covers
  whatever layouts and variants are actually installed on the system.

- Left-click cycles the layout (`hyprctl switchxkblayout current
  next`); right-click toggles the display between the text code and
  a flag emoji.

- The socket connection includes reconnect-with-backoff handling for
  cases where Hyprland isn't up yet or the socket drops.